### PR TITLE
Fix: Graceful shutdown on SIGTERM/SIGINT

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -545,14 +545,32 @@ async function start(): Promise<void> {
 
     // Start Telegram polling
     try {
-      const { startTelegramPolling } = await import('./notifications/telegram.js');
+      const { startTelegramPolling, stopTelegramPolling } = await import('./notifications/telegram.js');
       startTelegramPolling();
+
+      // Graceful shutdown — stop polling and close the server cleanly
+      const shutdown = async (signal: string) => {
+        console.log(`[startup] Received ${signal}, shutting down gracefully...`);
+        stopTelegramPolling();
+        if (server) {
+          server.close(() => {
+            console.log('[startup] HTTP server closed.');
+            process.exit(0);
+          });
+          // Force exit after 10s if graceful close hangs
+          setTimeout(() => { console.error('[startup] Force-exit after timeout.'); process.exit(1); }, 10_000);
+        } else {
+          process.exit(0);
+        }
+      };
+      process.on('SIGTERM', () => shutdown('SIGTERM'));
+      process.on('SIGINT', () => shutdown('SIGINT'));
     } catch (err: any) {
       console.warn('[startup] Telegram polling not started:', err.message);
     }
 
     // Start server
-    app.listen(PORT, () => {
+    const server = app.listen(PORT, () => {
       console.log(`[startup] Blueprint server running on http://localhost:${PORT}`);
       console.log(`[startup] Environment: ${process.env.NODE_ENV || 'development'}`);
       console.log(`[startup] API health: http://localhost:${PORT}/api/health`);

--- a/server/notifications/telegram.ts
+++ b/server/notifications/telegram.ts
@@ -156,6 +156,17 @@ export function startTelegramPolling(): void {
   if ((pollingInterval as any)?.unref) (pollingInterval as any).unref();
 }
 
+/**
+ * Stop the Telegram polling loop. Used during graceful shutdown.
+ */
+export function stopTelegramPolling(): void {
+  if (pollingInterval) {
+    clearInterval(pollingInterval);
+    pollingInterval = null;
+    console.log('[telegram] Polling loop stopped.');
+  }
+}
+
 async function pollBot({ botToken, chatId, businessId, businessName }: { botToken: string; chatId: string; businessId: string | null; businessName: string }): Promise<void> {
   const offset = (updateOffsets.get(botToken) ?? 0);
 


### PR DESCRIPTION
## What

Blueprint exits via `process.exit(1)` on fatal startup errors — no graceful cleanup of the Telegram polling loop or HTTP server. This is a rough shutdown that leaves connections hanging and can cause issues in production (Docker restart, systemd service stop, etc.).

## Fix

1. **`server/index.ts`** — captures the HTTP server instance returned by `app.listen()`, then registers `SIGTERM` and `SIGINT` handlers that:
   - call `stopTelegramPolling()` to clear the polling interval
   - close the HTTP server via `server.close()` (drains active connections)
   - `process.exit(0)` after the server closes
   - force-exit after 10s timeout as a safety net

2. **`server/notifications/telegram.ts`** — added `stopTelegramPolling()` which clears the `pollingInterval` and logs the stop.

## Testing

- `kill -SIGTERM <pid>` should trigger clean shutdown (Telegram polling stops, HTTP server closes, exit 0)
- `kill -SIGINT <pid>` (Ctrl-C) should behave the same
- Normal startup without signals should be unaffected
