### PR TITLE
fix(providers): add AbortSignal.timeout() to OpenAI-compatible fetch calls

### DIFF
--- a/server/lib/providers/openai.ts
+++ b/server/lib/providers/openai.ts
@@ -1,6 +1,7 @@
 import type { CompleteOptions, CompleteResult, ProviderCredentials } from './types.js';
 
 const DEFAULT_API_URL = 'https://api.openai.com/v1';
+const REQUEST_TIMEOUT_MS = 60_000;
 
 export const KNOWN_MODELS: string[] = [
   'gpt-4o',
@@ -27,7 +28,6 @@ export function estimateCost(model: string, inputTokens: number, outputTokens: n
 // All three call sites accept a baseUrl override so OpenAI-compatible
 // providers (MiniMax, Kimi, custom) can reuse this adapter without
 // duplicating the fetch/parse logic.
-
 export async function complete({ apiKey, baseUrl, model, messages, system, temperature = 0.7, max_tokens = 4096 }: CompleteOptions): Promise<CompleteResult> {
   const root = baseUrl || DEFAULT_API_URL;
   const allMessages: Array<{ role: string; content: string }> = [];
@@ -51,6 +51,12 @@ export async function complete({ apiKey, baseUrl, model, messages, system, tempe
       max_tokens,
       temperature,
     }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  }).catch(err => {
+    if (err.name === 'TimeoutError') {
+      throw new Error(`OpenAI API request timed out after ${REQUEST_TIMEOUT_MS / 1000}s. Check network and provider status.`);
+    }
+    throw err;
   });
 
   if (!response.ok) {
@@ -76,6 +82,7 @@ export async function listModels({ apiKey, baseUrl }: ProviderCredentials = {}):
   try {
     const response = await fetch(`${root}/models`, {
       headers: { 'Authorization': `Bearer ${apiKey}` },
+      signal: AbortSignal.timeout(10_000),
     });
     if (!response.ok) return KNOWN_MODELS;
     const data = await response.json() as { data?: Array<{ id: string }> };
@@ -90,6 +97,7 @@ export async function validateApiKey({ apiKey, baseUrl, ...rest }: ProviderCrede
   try {
     const modelsRes = await fetch(`${root}/models`, {
       headers: { 'Authorization': `Bearer ${apiKey}` },
+      signal: AbortSignal.timeout(10_000),
     });
     if (modelsRes.ok) return true;
 
@@ -109,6 +117,7 @@ export async function validateApiKey({ apiKey, baseUrl, ...rest }: ProviderCrede
         messages: [{ role: 'user', content: 'hi' }],
         max_tokens: 1,
       }),
+      signal: AbortSignal.timeout(10_000),
     });
     return chatRes.ok;
   } catch {


### PR DESCRIPTION
## What

Add `AbortSignal.timeout()` to all fetch calls in `server/lib/providers/openai.ts`:
- 60s timeout on the main `/chat/completions` call
- 10s timeout on `listModels` and `validateApiKey` probe calls

Also caught: `validateApiKey` was missing the `signal` on its `POST /chat/completions` probe call — would hang indefinitely if the provider was unresponsive.

## Why

Every LLM provider call without a timeout hangs forever if the provider is unreachable or rate-limited. Cascades to agent hangs, self-healer firing, KB pollution. 60s is reasonable for all providers.

`bun run --cwd server typecheck` passes.

Ref: #3