### PR TITLE
Safety hardening + green typecheck (audit follow-up, Phase 1)

### DIFF
--- a/server/agents/agent-runner.ts
+++ b/server/agents/agent-runner.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'url';
 import db, { generateId, audit } from '../db/db.js';
 import { createTask } from '../tasks/task-queue.js';
 import { createTaskEvent } from '../tasks/task-events.js';
-import { shouldAutoApprove, sendApprovalRequest } from '../tasks/approval.js';
+import { shouldAutoApprove, sendApprovalRequest, DANGEROUS_ACTION_TYPES } from '../tasks/approval.js';
 import { approveTask } from '../tasks/task-queue.js';
 import { runLLM, resolveProfileLLM, getFallbackLLM } from '../lib/llm-providers.js';
 import { buildMetricsContext } from './context-builders.js';
@@ -1479,6 +1479,18 @@ export async function runAgent(
           description = `${description ?? ''}\n\n ${restraint.confounding_warning}`.trim();
         }
 
+        // Security: the server — not the model — owns the trust tier and
+        // approval mode for destructive/outward-facing actions. A model (or
+        // injected external content) must not be able to lower its own gate by
+        // emitting trust_tier:'green'. Dangerous actions are forced to red +
+        // manual approval regardless of the model's proposed values.
+        let trustTier = taskDef.trust_tier ?? profile.trust_tier ?? 'yellow';
+        let approvalMode = profile.approval_mode ?? 'requires_approval';
+        if (taskDef.action_type && DANGEROUS_ACTION_TYPES.has(taskDef.action_type)) {
+          trustTier = 'red';
+          approvalMode = 'requires_approval';
+        }
+
         const task = createTask({
           business_id: businessId,
           signal_id: triggerId && trigger === 'signal' ? triggerId : null,
@@ -1487,11 +1499,11 @@ export async function runAgent(
           proposed_by: agentId,
           action_type: taskDef.action_type ?? null,
           action_payload: taskDef.action_payload ?? {},
-          trust_tier: taskDef.trust_tier ?? profile.trust_tier ?? 'yellow',
+          trust_tier: trustTier,
           priority: taskDef.priority ?? 'p2',
           confidence: taskDef.confidence ?? null,
           estimated_impact: taskDef.estimated_impact ?? null,
-          approval_mode: profile.approval_mode ?? 'requires_approval',
+          approval_mode: approvalMode,
           degraded_data: taskDef._degraded_data ? 1 : 0,
         }) as TaskRow | null;
 

--- a/server/agents/conductor.ts
+++ b/server/agents/conductor.ts
@@ -215,7 +215,7 @@ export async function runConductor(businessId: string): Promise<{ runs: Conducto
       try {
         console.log(`[conductor] Running agent '${agent.id}' for scheduled job '${job.id}'`);
         const result = await runAgentWithConstraints(agent.id, businessId, 'schedule', job.id);
-        runs.push({ agentId: agent.id, trigger: 'schedule', jobId: job.id, ...result });
+        runs.push({ agentId: agent.id, trigger: 'schedule', jobId: job.id, ...(result as Record<string, unknown>) });
       } catch (err) {
         console.error(`[conductor] Agent '${agent.id}' failed for job '${job.id}':`, (err as Error).message);
         errors.push({ agentId: agent.id, trigger: 'schedule', jobId: job.id, error: (err as Error).message });

--- a/server/connectors/server-access/index.ts
+++ b/server/connectors/server-access/index.ts
@@ -19,6 +19,10 @@ import db from '../../db/db.js';
 import { isPathSafe, isReadableFile } from './security.js';
 
 type Creds = Record<string, string | undefined>;
+// The connection layer requires a fully-formed credential shape (host/username
+// required). Connector methods receive decrypted creds as a loose string map,
+// so we cast at the createServerConnection boundary via this alias.
+type ServerConnCreds = Parameters<typeof createServerConnection>[0];
 
 // Structural type covering both SSH and FTP connections — exec is SSH-only
 // (guarded by `isSsh` checks at every call site).
@@ -185,7 +189,7 @@ const connector = {
   async healthCheck(credentials: Creds, config: Record<string, unknown> = {}): Promise<{ ok: boolean; error?: string; details?: unknown }> {
     let conn: ServerConn | undefined;
     try {
-      conn = await createServerConnection(credentials, config) as unknown as ServerConn;
+      conn = await createServerConnection(credentials as unknown as ServerConnCreds, config) as unknown as ServerConn;
       // Cheap canary: the connection itself succeeding is 90% of the signal.
       // If SSH, run a trivial exec to confirm we can execute commands.
       const serverInfo: Record<string, unknown> = { method: credentials.connectionMethod };
@@ -211,7 +215,7 @@ const connector = {
     const siteType = (config.siteType as string | undefined) || 'custom';
     const dirsToScan = SITE_STRUCTURES[siteType] ?? SITE_STRUCTURES.custom;
 
-    const conn = await createServerConnection(credentials, config) as unknown as ServerConn;
+    const conn = await createServerConnection(credentials as unknown as ServerConnCreds, config) as unknown as ServerConn;
     try {
       const isSsh = credentials.connectionMethod?.startsWith('ssh');
 
@@ -371,13 +375,13 @@ const connector = {
 
   // ─── Explicit read/write helpers (used by routes + executor) ───────────
   async readFile(credentials: Creds, remotePath: string): Promise<unknown> {
-    const conn = await createServerConnection(credentials, { rootPath: credentials.rootPath }) as unknown as ServerConn;
+    const conn = await createServerConnection(credentials as unknown as ServerConnCreds, { rootPath: credentials.rootPath }) as unknown as ServerConn;
     try { return await conn.readFile(remotePath); }
     finally { await conn.disconnect(); }
   },
 
   async listDirectory(credentials: Creds, remotePath: string, opts: Record<string, unknown> = {}): Promise<unknown[]> {
-    const conn = await createServerConnection(credentials, { rootPath: credentials.rootPath }) as unknown as ServerConn;
+    const conn = await createServerConnection(credentials as unknown as ServerConnCreds, { rootPath: credentials.rootPath }) as unknown as ServerConn;
     try { return await conn.listDirectory(remotePath, opts); }
     finally { await conn.disconnect(); }
   },

--- a/server/tasks/approval.ts
+++ b/server/tasks/approval.ts
@@ -28,6 +28,24 @@ type ApprovalPolicy = 'auto' | 'manual';
 type ApprovalPolicies = Record<string, ApprovalPolicy>;
 
 /**
+ * Action types that are destructive, irreversible, or outward-facing. These can
+ * NEVER be auto-approved and their trust tier is always forced to 'red' at task
+ * creation (see agent-runner). This is the server-owned safety floor: neither a
+ * settings policy nor a model-supplied trust_tier can lower the gate on these.
+ */
+export const DANGEROUS_ACTION_TYPES = new Set<string>([
+  'server_file_write',
+  'server_file_rollback',
+  'shopify_theme_edit',
+  'shopify_product_create',
+  'shopify_page_create',
+  'shopify_blog_post_create',
+  'github_pr',
+  'wix_seo_update',
+  'delete_product',
+]);
+
+/**
  * Read the user-configurable approval policies from the settings table.
  * Shape: { default?: 'auto' | 'manual', <action_type>?: 'auto' | 'manual' }
  */
@@ -51,6 +69,12 @@ function readApprovalPolicies(): ApprovalPolicies {
  *   3. Legacy fallback: trust_tier === 'green' && approval_mode === 'auto'
  */
 export function shouldAutoApprove(task: TaskRow): boolean {
+  // Hard floor: destructive / outward-facing actions are never auto-approved,
+  // regardless of any settings policy or trust tier. A blanket
+  // `default: 'auto'` policy (or an over-eager / injected model) must not be
+  // able to execute an irreversible change unattended.
+  if (task.action_type && DANGEROUS_ACTION_TYPES.has(task.action_type)) return false;
+
   const policies = readApprovalPolicies();
   const perAction = task.action_type ? policies[task.action_type] : undefined;
   if (perAction === 'auto') return true;

--- a/server/tasks/executor.ts
+++ b/server/tasks/executor.ts
@@ -1071,6 +1071,14 @@ export async function executeTask(taskId: string): Promise<{ ok: boolean; outcom
     return { ok: false, error: `action_type '${task.action_type}' is not executable` };
   }
 
+  // Defense-in-depth: the executor never runs a task that has not been
+  // explicitly approved. The status-transition table also blocks a
+  // non-approved → executing move, but this explicit gate keeps the executor
+  // safe regardless of caller, and independent of the transition table.
+  if (task.status !== 'approved') {
+    return { ok: false, error: `Task '${taskId}' is not approved (status: '${task.status}')` };
+  }
+
   // Transition: approved → executing
   try {
     updateTaskStatus(task.id, 'executing', 'system:executor', {});

--- a/server/tasks/task-queue.ts
+++ b/server/tasks/task-queue.ts
@@ -286,7 +286,7 @@ export function updateTaskStatus(
       import('../brain/action-windows.js').then((m) => {
         try {
           const task = db.prepare('SELECT * FROM tasks WHERE id = ?').get(id) as TaskRow;
-          m.recordActionMemory(task);
+          m.recordActionMemory(task as unknown as Record<string, unknown>);
           // Smart spacing — defer related pending tasks until the window closes
           import('../jobs/constraint-check.js').then((cc) => {
             try { cc.applySmartSpacing(task); } catch {}


### PR DESCRIPTION
## What this is

First, surgical slice of the full codebase audit — the changes that are unambiguously safe and directly close the highest-severity findings. Opened as **draft** for review.

## Why

The audit found a real exploitable chain: an LLM (or text injected via a connected data source such as a server PHP error log) can self-assign `trust_tier: 'green'`, and a single `approval_policies.default: 'auto'` setting then auto-approves **and executes** destructive actions (`server_file_write`, `shopify_theme_edit`, `github_pr`, `delete_product`). Separately, the server `tsc` was red (6 errors), so the project's strict type system — its best safety net — wasn't enforceable in CI.

## Changes

**Security — the server, not the model, now owns the trust/approval decision:**
- `executeTask()` refuses any task whose `status !== 'approved'` (defense-in-depth, independent of the status-transition table). Verified all current callers approve first, so no behaviour change on the happy path.
- New `DANGEROUS_ACTION_TYPES` set. These can **never** be auto-approved — `shouldAutoApprove()` hard-floors them to `false` regardless of settings policy, and `agent-runner` forces their `trust_tier` to `red` / `requires_approval` regardless of the model's proposed values.

**Type safety — server `tsc --noEmit` now passes (6 → 0 errors):**
- `conductor.ts`: cast `unknown` result before spread.
- `connectors/server-access/index.ts`: cast loose `Creds` to the connection layer's credential type at the 4 `createServerConnection` call sites.
- `tasks/task-queue.ts`: cast `TaskRow` for `recordActionMemory()`.

## Verification
- `bun run typecheck` passes for **both** server and client.
- No business logic changed; all changes either add a guard or fix a type cast.

## Not in this PR (tracked in the audit)
Recommended next: enforce typecheck + add `bun test` and lint in CI (currently build-only); sanitise connector/log text before it enters prompts; route all connectors through the outbound allowlist; fix GSC 50-row truncation and the hardcoded google-ads date; add a `reverted` task state (rollback currently marks tasks `failed`); broaden outcome-verification metric coverage (only 6 of ~25 action types today). Happy to land these in follow-up PRs.

https://claude.ai/code/session_014nBD52MaSgA5yNED6mCi1H

---
_Generated by [Claude Code](https://claude.ai/code/session_014nBD52MaSgA5yNED6mCi1H)_