### PR TITLE
Fix connector data-accuracy bugs (GSC pagination, Google Ads date, Shopify truncation, GA4 bounce)

### DIFF
--- a/server/connectors/ga4/index.ts
+++ b/server/connectors/ga4/index.ts
@@ -1,5 +1,6 @@
 import fetch from 'node-fetch';
 import { readGoogleOAuthConfig } from '../../lib/google-oauth-config.js';
+import { sessionsWeightedAverage } from '../metrics-math.js';
 
 type Creds = Record<string, string | undefined>;
 
@@ -240,21 +241,24 @@ async function fetchReport(creds: Creds, propertyId: string, params: Record<stri
 
   // Aggregate totals
   function aggregate(rangeIndex: number): { sessions: number; activeUsers: number; bounceRate: number; conversions: number } {
-    let sessions = 0, users = 0, bounceRate = 0, conversions = 0, count = 0;
+    let sessions = 0, users = 0, conversions = 0;
+    const bouncePairs: Array<{ value: number; weight: number }> = [];
     for (const row of allRows) {
       if (row.dataRangeIndex !== undefined && row.dataRangeIndex !== rangeIndex) continue;
       if (row.dataRangeIndex === undefined && rangeIndex !== 0) continue;
       const metricValues = row.metricValues as Array<Record<string, string>> | undefined;
-      sessions += parseFloat((metricValues?.[0]?.value ?? '0') as string);
+      const rowSessions = parseFloat((metricValues?.[0]?.value ?? '0') as string);
+      sessions += rowSessions;
       users += parseFloat((metricValues?.[1]?.value ?? '0') as string);
-      bounceRate += parseFloat((metricValues?.[2]?.value ?? '0') as string);
+      // bounceRate is a per-row ratio — weight it by that row's sessions rather
+      // than taking an unweighted mean of daily rates (which skewed the signal).
+      bouncePairs.push({ value: parseFloat((metricValues?.[2]?.value ?? '0') as string), weight: rowSessions });
       conversions += parseFloat((metricValues?.[3]?.value ?? '0') as string);
-      count++;
     }
     return {
       sessions: Math.round(sessions),
       activeUsers: Math.round(users),
-      bounceRate: count > 0 ? Math.round((bounceRate / count) * 100) / 100 : 0,
+      bounceRate: Math.round(sessionsWeightedAverage(bouncePairs) * 100) / 100,
       conversions: Math.round(conversions),
     };
   }

--- a/server/connectors/google-ads/index.ts
+++ b/server/connectors/google-ads/index.ts
@@ -10,6 +10,7 @@
  * NOTE: cost_micros is in micros — divide by 1,000,000 to get currency value.
  */
 import { withRetry, checkedFetch } from '../../lib/rate-limiter.js';
+import { previousPeriodRange } from '../metrics-math.js';
 
 type Creds = Record<string, string | undefined>;
 
@@ -136,6 +137,10 @@ const connector = {
     const fresh = await ensureFreshToken(credentials);
     const managerAccountId = (params?.managerAccountId as string | undefined) || credentials?.managerAccountId;
 
+    // Previous 30-day window (the 30 days before LAST_30_DAYS), computed from
+    // today — replaces a hard-coded March-2025 range that broke every trend.
+    const prev = previousPeriodRange(new Date(), 30);
+
     // Run all GAQL queries in parallel
     const [accountTotals, accountTotalsPrev, campaigns, keywords] = await Promise.all([
       gaqlQuery(
@@ -153,7 +158,7 @@ const connector = {
            metrics.conversions, metrics.conversions_value,
            metrics.average_cpc, metrics.ctr
          FROM customer
-         WHERE segments.date BETWEEN '2025-03-01' AND '2025-03-31'`,
+         WHERE segments.date BETWEEN '${prev.start}' AND '${prev.end}'`,
         fresh, customerId, managerAccountId
       ).catch(() => ({ results: [] })),
       gaqlQuery(

--- a/server/connectors/gsc/index.ts
+++ b/server/connectors/gsc/index.ts
@@ -263,51 +263,68 @@ async function fetchSearchAnalytics(creds: Creds, params: Record<string, unknown
   const endDatePrev = dateString(11);
 
   async function query(startDate: string, endDate: string): Promise<Array<Record<string, unknown>>> {
-    const body = {
-      startDate,
-      endDate,
-      dimensions: ['query'],
-      rowLimit: 50,
-      orderBy: [{ fieldName: 'clicks', sortOrder: 'DESCENDING' }],
-    };
+    // Paginate. GSC allows up to 25000 rows/request; the old code took only the
+    // top 50 by clicks, so avg_position / CTR / keyword-opportunity metrics were
+    // computed on a tiny slice. Page through up to MAX_ROWS keywords.
+    const PAGE = 1000;
+    const MAX_ROWS = 5000;
+    const out: Array<Record<string, unknown>> = [];
+    let startRow = 0;
 
-    const res = await fetch(
-      `${GSC_BASE}/sites/${encodeURIComponent(siteUrl!)}/searchAnalytics/query`,
-      {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${creds.accessToken}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(body),
-      }
-    );
+    while (out.length < MAX_ROWS) {
+      const body = {
+        startDate,
+        endDate,
+        dimensions: ['query'],
+        rowLimit: PAGE,
+        startRow,
+        orderBy: [{ fieldName: 'clicks', sortOrder: 'DESCENDING' }],
+      };
 
-    if (!res.ok) {
-      const err = await res.text();
-      // 403 with "User does not have sufficient permission for site" almost
-      // always means the URL variant doesn't match what was verified in
-      // Search Console (http vs https, www vs apex, trailing slash). Help
-      // the user diagnose without reading Google's terse message.
-      if (res.status === 403 && /sufficient permission for site/i.test(err)) {
-        throw new Error(
-          `GSC: this Google account isn't verified for '${siteUrl}'. ` +
-          'Search Console treats http vs https and www vs the apex domain as separate properties. ' +
-          'Open Settings → Connectors → your GSC connector → Configure to pick from your verified sites, ' +
-          'or add a Domain property in Search Console to cover all variants.'
-        );
+      const res = await fetch(
+        `${GSC_BASE}/sites/${encodeURIComponent(siteUrl!)}/searchAnalytics/query`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${creds.accessToken}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(body),
+        }
+      );
+
+      if (!res.ok) {
+        const err = await res.text();
+        // 403 "sufficient permission for site" almost always means the URL
+        // variant doesn't match what was verified in Search Console
+        // (http vs https, www vs apex, trailing slash).
+        if (res.status === 403 && /sufficient permission for site/i.test(err)) {
+          throw new Error(
+            `GSC: this Google account isn't verified for '${siteUrl}'. ` +
+            'Search Console treats http vs https and www vs the apex domain as separate properties. ' +
+            'Open Settings → Connectors → your GSC connector → Configure to pick from your verified sites, ' +
+            'or add a Domain property in Search Console to cover all variants.'
+          );
+        }
+        throw new Error(`GSC search analytics error ${res.status}: ${err.substring(0, 300)}`);
       }
-      throw new Error(`GSC search analytics error ${res.status}: ${err.substring(0, 300)}`);
+
+      const data = await res.json() as { rows?: Array<{ keys: string[]; clicks: number; impressions: number; ctr: number; position: number }> };
+      const page = data.rows ?? [];
+      for (const row of page) {
+        out.push({
+          query: row.keys[0],
+          clicks: row.clicks,
+          impressions: row.impressions,
+          ctr: row.ctr,
+          position: row.position,
+        });
+      }
+      if (page.length < PAGE) break; // last page
+      startRow += PAGE;
     }
 
-    const data = await res.json() as { rows?: Array<{ keys: string[]; clicks: number; impressions: number; ctr: number; position: number }> };
-    return (data.rows ?? []).map(row => ({
-      query: row.keys[0],
-      clicks: row.clicks,
-      impressions: row.impressions,
-      ctr: row.ctr,
-      position: row.position,
-    }));
+    return out;
   }
 
   const [current, previous] = await Promise.all([

--- a/server/connectors/metrics-math.test.ts
+++ b/server/connectors/metrics-math.test.ts
@@ -1,0 +1,39 @@
+import { test, expect, describe } from 'bun:test';
+import { previousPeriodRange, sessionsWeightedAverage } from './metrics-math.js';
+
+describe('previousPeriodRange', () => {
+  test('returns the 30 days immediately before the trailing-30 window (not a hardcoded date)', () => {
+    const now = new Date('2026-05-29T00:00:00Z');
+    expect(previousPeriodRange(now, 30)).toEqual({ start: '2026-03-30', end: '2026-04-28' });
+  });
+
+  test('is relative to "now" — different month yields a different range', () => {
+    const r = previousPeriodRange(new Date('2026-01-15T00:00:00Z'), 30);
+    expect(r.start).toBe('2025-11-16');
+    expect(r.end).toBe('2025-12-15');
+    // The old bug returned March 2025 regardless of date — guard against regressing to any fixed year.
+    expect(r.start.startsWith('2025-03')).toBe(false);
+  });
+
+  test('honours a custom window length', () => {
+    expect(previousPeriodRange(new Date('2026-05-29T00:00:00Z'), 7)).toEqual({ start: '2026-05-15', end: '2026-05-21' });
+  });
+});
+
+describe('sessionsWeightedAverage', () => {
+  test('weights ratios by their weight, not a flat mean', () => {
+    // Flat mean would be 0.5; sessions-weighted is (0.2*100 + 0.8*900)/1000 = 0.74
+    const v = sessionsWeightedAverage([{ value: 0.2, weight: 100 }, { value: 0.8, weight: 900 }]);
+    expect(v).toBeCloseTo(0.74, 5);
+  });
+
+  test('ignores zero / negative / non-finite weights and values', () => {
+    expect(sessionsWeightedAverage([{ value: 0.5, weight: 0 }, { value: 0.9, weight: -3 }, { value: 1, weight: 50 }])).toBeCloseTo(1, 5);
+    expect(sessionsWeightedAverage([{ value: NaN, weight: 10 }, { value: 0.4, weight: 10 }])).toBeCloseTo(0.4, 5);
+  });
+
+  test('returns 0 when there is no positive weight', () => {
+    expect(sessionsWeightedAverage([])).toBe(0);
+    expect(sessionsWeightedAverage([{ value: 0.9, weight: 0 }])).toBe(0);
+  });
+});

--- a/server/connectors/metrics-math.ts
+++ b/server/connectors/metrics-math.ts
@@ -1,0 +1,42 @@
+/**
+ * Small pure helpers for connector metric maths. Kept dependency-free and
+ * separately unit-tested so the tricky bits (period maths, weighted ratios)
+ * aren't buried inside fetch loops.
+ */
+
+function fmtDate(d: Date): string {
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
+}
+
+/**
+ * The `days`-day window immediately BEFORE the trailing `days`-day window that
+ * ends yesterday (matching Google Ads' DURING LAST_30_DAYS, which excludes
+ * today). For days=30 and today T: returns [T-60, T-31].
+ *
+ * Replaces a previously hard-coded 'BETWEEN 2025-03-01 AND 2025-03-31' that
+ * made every previous-period comparison permanently wrong.
+ */
+export function previousPeriodRange(now: Date, days = 30): { start: string; end: string } {
+  const end = new Date(now);
+  end.setUTCDate(end.getUTCDate() - (days + 1));
+  const start = new Date(now);
+  start.setUTCDate(start.getUTCDate() - 2 * days);
+  return { start: fmtDate(start), end: fmtDate(end) };
+}
+
+/**
+ * Weighted average of per-row ratios (e.g. a period bounce rate weighted by
+ * each day's sessions), not the unweighted mean of daily rates. Rows with a
+ * non-positive or non-finite weight are ignored. Returns 0 when there is no
+ * positive weight.
+ */
+export function sessionsWeightedAverage(pairs: Array<{ value: number; weight: number }>): number {
+  let weighted = 0;
+  let totalWeight = 0;
+  for (const p of pairs) {
+    if (!Number.isFinite(p.value) || !Number.isFinite(p.weight) || p.weight <= 0) continue;
+    weighted += p.value * p.weight;
+    totalWeight += p.weight;
+  }
+  return totalWeight > 0 ? weighted / totalWeight : 0;
+}

--- a/server/connectors/shopify/index.ts
+++ b/server/connectors/shopify/index.ts
@@ -119,7 +119,16 @@ async function fetchProducts(credentials: Creds): Promise<ShopifyProduct[]> {
 
   while (url) {
     const res = await shopifyFetch(credentials, url);
-    if (!res.ok) break;
+    if (!res.ok) {
+      // Don't silently return a partial list — a truncated catalogue would be
+      // reported as the whole catalogue and trip false "products dropped"
+      // signals. Surface the failure so the sync is marked errored instead.
+      const body = await res.text().catch(() => '');
+      throw new Error(
+        `Shopify products fetch failed (status ${res.status}) after ${products.length} product(s); ` +
+        `aborting to avoid reporting a truncated catalogue. ${body.slice(0, 200)}`
+      );
+    }
     const data = await res.json() as { products?: ShopifyProduct[] };
     products.push(...(data.products ?? []));
 


### PR DESCRIPTION
Corrects four audit-flagged bugs where connector data was **silently wrong** — which would make your real-data testing misleading and trip false signals. Picked before the security hardening because it directly affects testing *accuracy now* (security matters for public exposure, not local testing).

## Fixes
- **GSC — pagination.** `fetchSearchAnalytics` took only the **top 50 keywords by clicks** (`rowLimit: 50`, no paging), so `avg_position`, CTR, keyword-opportunity metrics and every ranking signal were computed on a tiny slice. Now pages through (1,000/page, capped at 5,000). *(`gsc/index.ts`)*
- **Google Ads — previous period.** The prev-vs-current comparison was hard-coded to `BETWEEN '2025-03-01' AND '2025-03-31'`, making every trend/`*_prev` delta permanently wrong. Now computes the 30 days before `LAST_30_DAYS` from today. *(`google-ads/index.ts`)*
- **Shopify — silent truncation.** `fetchProducts` did `if (!res.ok) break;`, returning a partial catalogue as if complete (→ false "products dropped" signals). Now throws so the sync is marked errored instead of reporting wrong data. *(`shopify/index.ts`)*
- **GA4 — bounce rate.** Was an unweighted mean of daily bounce rates; now **sessions-weighted**, so `bounce_rate_spike` isn't skewed by low-traffic days. *(`ga4/index.ts`)*

## New / tested
- `server/connectors/metrics-math.ts` — pure, dependency-free `previousPeriodRange()` + `sessionsWeightedAverage()`, extracted so the tricky maths is unit-tested rather than buried in fetch loops.
- `server/connectors/metrics-math.test.ts` — 6 cases (period maths is relative-to-now and never a fixed year; weighting is correct; ignores zero/negative/NaN weights).

## Verification
`bun run typecheck` (server + client) clean; `bun run --cwd server test` → **77 pass** (71 + 6 new).

## Not in this PR (follow-ups)
- No 429/backoff on Shopify/GA4/GSC/Google Ads raw `node-fetch` calls (separate hardening pass).
- WordPress/Stannp report a single page's `.length` as the "total" (understated counts) — lower impact; deferred.
- Pervasive `.catch(() => [])` swallows that turn outages into false "all-clear" — tracked under the `find-fix-bugs` Tier-1 roadmap (observability).

https://claude.ai/code/session_014nBD52MaSgA5yNED6mCi1H

---
_Generated by [Claude Code](https://claude.ai/code/session_014nBD52MaSgA5yNED6mCi1H)_