### PR TITLE
Audit pass: connector hardening, metric bug fixes, signal-rule & retry tests

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -49,7 +49,7 @@
         "@anthropic-ai/sdk": "^0.27.0",
         "@isomorphic-git/lightning-fs": "^4.6.0",
         "basic-ftp": "^5.2.2",
-        "bcryptjs": "^2.4.3",
+        "bcryptjs": "^3.0.2",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.18.3",
@@ -66,7 +66,6 @@
         "uuid": "^9.0.1",
       },
       "devDependencies": {
-        "@types/bcryptjs": "^3.0.0",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
         "@types/express-session": "^1.18.2",
@@ -319,8 +318,6 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
-    "@types/bcryptjs": ["@types/bcryptjs@3.0.0", "", { "dependencies": { "bcryptjs": "*" } }, "sha512-WRZOuCuaz8UcZZE4R5HXTco2goQSI2XxjGY3hbM/xDvwmqFWd4ivooImsMx65OKM6CtNKbnZ5YL+YwAwK7c1dg=="],
-
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
@@ -421,7 +418,7 @@
 
     "bcrypt-pbkdf": ["bcrypt-pbkdf@1.0.2", "", { "dependencies": { "tweetnacl": "^0.14.3" } }, "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w=="],
 
-    "bcryptjs": ["bcryptjs@2.4.3", "", {}, "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="],
+    "bcryptjs": ["bcryptjs@3.0.3", "", { "bin": { "bcrypt": "bin/bcrypt" } }, "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g=="],
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 

--- a/client/src/pages/ConnectorDataPage.tsx
+++ b/client/src/pages/ConnectorDataPage.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck — complex connector data visualization; connector shapes are too varied to type explicitly
 import React, { useState, useEffect, useCallback } from 'react'
 import { useParams, useSearchParams, useNavigate } from 'react-router-dom'
 import { formatDistanceToNow, format, parseISO } from 'date-fns'
@@ -77,7 +76,7 @@ const RANGE_LABELS  = { today: 'Today', yesterday: 'Yesterday', '7d': '7D', '14d
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-function getRangeBounds(range) {
+function getRangeBounds(range: any) {
   const now = new Date()
   if (range === 'today') {
     const start = new Date(now.getFullYear(), now.getMonth(), now.getDate())
@@ -91,18 +90,18 @@ function getRangeBounds(range) {
   return { start: new Date(now.getTime() - days * 86400000), end: now }
 }
 
-function getPrevBounds(range) {
+function getPrevBounds(range: any) {
   const { start, end } = getRangeBounds(range)
   const duration = end.getTime() - start.getTime()
   return { start: new Date(start.getTime() - duration), end: start }
 }
 
-function pctChange(current, previous) {
+function pctChange(current: any, previous: any) {
   if (!previous || previous === 0) return null
   return ((current - previous) / previous) * 100
 }
 
-function TrendBadge({ current, previous, invertPolarity = false, suffix = '' }) {
+function TrendBadge({ current, previous, invertPolarity = false, suffix = '' }: any) {
   const pct = pctChange(current, previous)
   if (pct === null) return null
   const good = invertPolarity ? pct < 0 : pct > 0
@@ -119,7 +118,7 @@ function TrendBadge({ current, previous, invertPolarity = false, suffix = '' }) 
   )
 }
 
-function MetricCard({ label, value, previous, format: fmt = 'number', invertPolarity = false, accent }) {
+function MetricCard({ label, value, previous, format: fmt = 'number', invertPolarity = false, accent }: any) {
   const display = fmt === 'currency' ? `£${Number(value || 0).toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
     : fmt === 'pct' ? `${(value || 0).toFixed(1)}%`
     : fmt === 'duration' ? `${Math.floor((value || 0) / 60)}m ${Math.round((value || 0) % 60)}s`
@@ -142,12 +141,12 @@ function MetricCard({ label, value, previous, format: fmt = 'number', invertPola
   )
 }
 
-function CustomTooltip({ active, payload, label }) {
+function CustomTooltip({ active, payload, label }: any) {
   if (!active || !payload?.length) return null
   return (
     <div style={{ ...chartDefaults.tooltip.contentStyle, padding: '8px 12px' }}>
       <div style={{ fontFamily: 'var(--bp-font-mono)', fontSize: 10, color: 'var(--bp-text-3)', marginBottom: 4 }}>{label}</div>
-      {payload.map((p, i) => (
+      {payload.map((p: any, i: any) => (
         <div key={i} style={{ fontFamily: 'var(--bp-font-mono)', fontSize: 11, color: p.color || 'var(--bp-text)' }}>
           {p.name}: {typeof p.value === 'number' ? p.value.toLocaleString() : p.value}
         </div>
@@ -158,7 +157,7 @@ function CustomTooltip({ active, payload, label }) {
 
 // ─── Raw Data Tab ─────────────────────────────────────────────────────────────
 
-function RawDataTab({ data }) {
+function RawDataTab({ data }: any) {
   const [copied, setCopied] = useState(false)
   const json = JSON.stringify(data, null, 2)
   function copy() {
@@ -184,14 +183,14 @@ function RawDataTab({ data }) {
 
 // ─── GSC Tabs ────────────────────────────────────────────────────────────────
 
-function GSCOverview({ metrics }) {
+function GSCOverview({ metrics }: any) {
   const { latest, series, summary } = metrics
   const clicks = latest['clicks'] ?? 0
   const impressions = latest['impressions'] ?? 0
   const ctr = latest['ctr'] ?? 0
   const position = latest['position'] ?? 0
 
-  const clicksSeries = (series['clicks'] || []).map(m => ({
+  const clicksSeries = (series['clicks'] || []).map((m: any) => ({
     date: format(parseISO(m.recorded_at), 'MMM d'),
     clicks: m.metric_value,
   }))
@@ -229,7 +228,7 @@ function GSCOverview({ metrics }) {
   )
 }
 
-function GSCKeywords({ metrics }) {
+function GSCKeywords({ metrics }: any) {
   // GSC connector writes 'gsc.keywords' with data = top 100 keyword objects.
   // Server alias exposes both 'keywords' (scalar count) and 'keywords_data'
   // (the array). Accept either for backwards compat.
@@ -245,12 +244,12 @@ function GSCKeywords({ metrics }) {
   }
 
   // Opportunity finder: high impressions (>100), low CTR (<3%), position 11-20
-  const avgCTR = keywords.reduce((s, k) => s + (k.ctr || 0), 0) / (keywords.length || 1)
-  const opportunities = keywords.filter(k =>
+  const avgCTR = keywords.reduce((s: any, k: any) => s + (k.ctr || 0), 0) / (keywords.length || 1)
+  const opportunities = keywords.filter((k: any) =>
     (k.impressions || 0) > 100 &&
     (k.ctr || 0) < Math.max(avgCTR, 0.03) &&
     (k.position || 99) >= 8 && (k.position || 99) <= 25
-  ).sort((a, b) => (b.impressions || 0) - (a.impressions || 0)).slice(0, 8)
+  ).sort((a: any, b: any) => (b.impressions || 0) - (a.impressions || 0)).slice(0, 8)
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
@@ -267,7 +266,7 @@ function GSCKeywords({ metrics }) {
             </span>
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-            {opportunities.map((kw, i) => {
+            {opportunities.map((kw: any, i: any) => {
               const kw_text = kw.keys?.[0] || kw.query || kw.keyword
               const ctrPct = ((kw.ctr || 0) * 100).toFixed(1)
               const pos = (kw.position || 0).toFixed(1)
@@ -309,7 +308,7 @@ function GSCKeywords({ metrics }) {
             </tr>
           </thead>
           <tbody>
-            {keywords.slice(0, 50).map((kw, i) => (
+            {keywords.slice(0, 50).map((kw: any, i: any) => (
               <tr key={i} style={{ borderBottom: '1px solid rgba(255,255,255,0.04)' }}>
                 <td style={{ padding: '9px 16px', fontFamily: 'var(--bp-font-mono)', fontSize: 11, color: 'var(--bp-text)' }}>{kw.keys?.[0] || kw.query || kw.keyword}</td>
                 <td style={{ padding: '9px 16px', fontFamily: 'var(--bp-font-mono)', fontSize: 11, color: 'var(--bp-text-2)' }}>{(kw.clicks || 0).toLocaleString()}</td>
@@ -332,7 +331,7 @@ function GSCKeywords({ metrics }) {
   )
 }
 
-function GSCPages({ metrics }) {
+function GSCPages({ metrics }: any) {
   // GSC doesn't emit a separate top_pages metric — derive from the same
   // keyword-level data, grouping by page URL.
   const rawKeywords = metrics.latest['keywords_data']
@@ -358,7 +357,7 @@ function GSCPages({ metrics }) {
     clicks: p.clicks,
     impressions: p.impressions,
     ctr: p.impressions > 0 ? p.clicks / p.impressions : 0,
-    position: p.positions.length > 0 ? p.positions.reduce((a, b) => a + b, 0) / p.positions.length : 0,
+    position: p.positions.length > 0 ? p.positions.reduce((a: any, b: any) => a + b, 0) / p.positions.length : 0,
     queries: p.queries,
   })).sort((a, b) => b.clicks - a.clicks)
 
@@ -377,7 +376,7 @@ function GSCPages({ metrics }) {
           </tr>
         </thead>
         <tbody>
-          {pages.slice(0, 50).map((p, i) => (
+          {pages.slice(0, 50).map((p: any, i) => (
             <tr key={i} style={{ borderBottom: '1px solid rgba(255,255,255,0.04)' }}>
               <td style={{ padding: '9px 16px', fontFamily: 'var(--bp-font-mono)', fontSize: 10, color: 'var(--bp-text)', maxWidth: 360, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                 {p.keys?.[0] || p.page || p.url}
@@ -396,7 +395,7 @@ function GSCPages({ metrics }) {
 
 // ─── GA4 Tabs ─────────────────────────────────────────────────────────────────
 
-function GA4Overview({ metrics }) {
+function GA4Overview({ metrics }: any) {
   const { latest, series, summary } = metrics
   const sessions = latest['sessions'] ?? 0
   const users = latest['users'] ?? 0
@@ -405,7 +404,7 @@ function GA4Overview({ metrics }) {
   const pageviews = latest['pageviews'] ?? 0
   const newUsers = latest['new_users'] ?? 0
 
-  const sessionsSeries = (series['sessions'] || []).map(m => ({
+  const sessionsSeries = (series['sessions'] || []).map((m: any) => ({
     date: format(parseISO(m.recorded_at), 'MMM d'),
     sessions: m.metric_value,
   }))
@@ -445,9 +444,9 @@ function GA4Overview({ metrics }) {
   )
 }
 
-function GA4Traffic({ metrics }) {
+function GA4Traffic({ metrics }: any) {
   const { series } = metrics
-  const sessionsSeries = (series['sessions'] || []).map(m => ({
+  const sessionsSeries = (series['sessions'] || []).map((m: any) => ({
     date: format(parseISO(m.recorded_at), 'MMM d'),
     sessions: m.metric_value,
   }))
@@ -487,7 +486,7 @@ function GA4Traffic({ metrics }) {
               </tr>
             </thead>
             <tbody>
-              {sources.map((s, i) => (
+              {sources.map((s: any, i: any) => (
                 <tr key={i} style={{ borderBottom: '1px solid rgba(255,255,255,0.04)' }}>
                   <td style={{ padding: '8px 0', fontFamily: 'var(--bp-font-mono)', fontSize: 11, color: 'var(--bp-text)' }}>{s.source || s.channel || s.medium}</td>
                   <td style={{ padding: '8px 0', fontFamily: 'var(--bp-font-mono)', fontSize: 11, color: 'var(--bp-text-2)' }}>{(s.sessions || 0).toLocaleString()}</td>
@@ -505,12 +504,12 @@ function GA4Traffic({ metrics }) {
 
 // ─── PageSpeed Tabs ───────────────────────────────────────────────────────────
 
-function PSOverview({ metrics }) {
+function PSOverview({ metrics }: any) {
   const { latest } = metrics
   // Defensive scalar coercion: an alias may resolve to an object (the
   // sibling metric_data) when something upstream is wrong. Strip to a
   // number so we never end up multiplying an object → NaN.
-  const num = (v) => {
+  const num = (v: any) => {
     if (typeof v === 'number' && Number.isFinite(v)) return v
     if (v && typeof v === 'object') {
       // pagespeed connector stores the entire scores object as data
@@ -533,12 +532,12 @@ function PSOverview({ metrics }) {
 
   // Normalize 0-1 scores to 0-100 (the connector now writes 0-100 already
   // but this stays correct for either scale).
-  const norm = (v) => v <= 1 ? Math.round(v * 100) : Math.round(v)
+  const norm = (v: any) => v <= 1 ? Math.round(v * 100) : Math.round(v)
 
   const cwvItems = [
-    { label: 'LCP', value: mobile.lcp, unit: 'ms', threshold: 2500, invert: true, format: (v) => `${v}ms`, good: v => v < 2500, warn: v => v < 4000 },
-    { label: 'CLS', value: mobile.cls, unit: '', threshold: 0.1, invert: true, format: (v) => v?.toFixed(3), good: v => v < 0.1, warn: v => v < 0.25 },
-    { label: 'FCP', value: mobile.fcp, unit: 'ms', invert: true, format: (v) => `${v}ms`, good: v => v < 1800, warn: v => v < 3000 },
+    { label: 'LCP', value: mobile.lcp, unit: 'ms', threshold: 2500, invert: true, format: (v: any) => `${v}ms`, good: (v: any) => v < 2500, warn: (v: any) => v < 4000 },
+    { label: 'CLS', value: mobile.cls, unit: '', threshold: 0.1, invert: true, format: (v: any) => v?.toFixed(3), good: (v: any) => v < 0.1, warn: (v: any) => v < 0.25 },
+    { label: 'FCP', value: mobile.fcp, unit: 'ms', invert: true, format: (v: any) => `${v}ms`, good: (v: any) => v < 1800, warn: (v: any) => v < 3000 },
   ]
 
   return (
@@ -548,16 +547,16 @@ function PSOverview({ metrics }) {
         <div style={{ fontFamily: 'var(--bp-font-mono)', fontSize: 9, color: 'var(--bp-text-3)', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: 16 }}>Mobile Scores</div>
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 8 }}>
           <div style={{ textAlign: 'center' }}>
-            <Gauge value={norm(mobile.performance)} max={100} label="Performance" size={100} goodThreshold={90} warnThreshold={50} />
+            <Gauge value={norm(mobile.performance)} max={100} label="Performance" goodThreshold={90} needsWorkThreshold={50} />
           </div>
           <div style={{ textAlign: 'center' }}>
-            <Gauge value={norm(mobile.accessibility)} max={100} label="Accessibility" size={100} goodThreshold={90} warnThreshold={50} />
+            <Gauge value={norm(mobile.accessibility)} max={100} label="Accessibility" goodThreshold={90} needsWorkThreshold={50} />
           </div>
           <div style={{ textAlign: 'center' }}>
-            <Gauge value={norm(mobile.bestPractices)} max={100} label="Best Practices" size={100} goodThreshold={90} warnThreshold={50} />
+            <Gauge value={norm(mobile.bestPractices)} max={100} label="Best Practices" goodThreshold={90} needsWorkThreshold={50} />
           </div>
           <div style={{ textAlign: 'center' }}>
-            <Gauge value={norm(mobile.seo)} max={100} label="SEO" size={100} goodThreshold={90} warnThreshold={50} />
+            <Gauge value={norm(mobile.seo)} max={100} label="SEO" goodThreshold={90} needsWorkThreshold={50} />
           </div>
         </div>
       </div>
@@ -593,9 +592,9 @@ function PSOverview({ metrics }) {
 
 // ─── PageSpeed Desktop Tab ────────────────────────────────────────────────────
 
-function PSDesktop({ metrics }) {
+function PSDesktop({ metrics }: any) {
   const { latest } = metrics
-  const norm = (v) => v <= 1 ? Math.round(v * 100) : Math.round(v)
+  const norm = (v: any) => v <= 1 ? Math.round(v * 100) : Math.round(v)
   const desktop = {
     performance:   norm(latest['performance_desktop'] ?? 0),
     accessibility: norm(latest['accessibility_desktop'] ?? 0),
@@ -606,19 +605,19 @@ function PSDesktop({ metrics }) {
     fcp:           latest['fcp_desktop'] ?? 0,
   }
   const cwvItems = [
-    { label: 'LCP', value: desktop.lcp, format: (v) => `${v}ms`, good: v => v < 2500, warn: v => v < 4000 },
-    { label: 'CLS', value: desktop.cls, format: (v) => v?.toFixed(3), good: v => v < 0.1, warn: v => v < 0.25 },
-    { label: 'FCP', value: desktop.fcp, format: (v) => `${v}ms`, good: v => v < 1800, warn: v => v < 3000 },
+    { label: 'LCP', value: desktop.lcp, format: (v: any) => `${v}ms`, good: (v: any) => v < 2500, warn: (v: any) => v < 4000 },
+    { label: 'CLS', value: desktop.cls, format: (v: any) => v?.toFixed(3), good: (v: any) => v < 0.1, warn: (v: any) => v < 0.25 },
+    { label: 'FCP', value: desktop.fcp, format: (v: any) => `${v}ms`, good: (v: any) => v < 1800, warn: (v: any) => v < 3000 },
   ]
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
       <div className="bp-card" style={{ padding: '20px' }}>
         <div style={{ fontFamily: 'var(--bp-font-mono)', fontSize: 9, color: 'var(--bp-text-3)', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: 16 }}>Desktop Scores</div>
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 8 }}>
-          <div style={{ textAlign: 'center' }}><Gauge value={desktop.performance} max={100} label="Performance" size={100} goodThreshold={90} warnThreshold={50} /></div>
-          <div style={{ textAlign: 'center' }}><Gauge value={desktop.accessibility} max={100} label="Accessibility" size={100} goodThreshold={90} warnThreshold={50} /></div>
-          <div style={{ textAlign: 'center' }}><Gauge value={desktop.bestPractices} max={100} label="Best Practices" size={100} goodThreshold={90} warnThreshold={50} /></div>
-          <div style={{ textAlign: 'center' }}><Gauge value={desktop.seo} max={100} label="SEO" size={100} goodThreshold={90} warnThreshold={50} /></div>
+          <div style={{ textAlign: 'center' }}><Gauge value={desktop.performance} max={100} label="Performance" goodThreshold={90} needsWorkThreshold={50} /></div>
+          <div style={{ textAlign: 'center' }}><Gauge value={desktop.accessibility} max={100} label="Accessibility" goodThreshold={90} needsWorkThreshold={50} /></div>
+          <div style={{ textAlign: 'center' }}><Gauge value={desktop.bestPractices} max={100} label="Best Practices" goodThreshold={90} needsWorkThreshold={50} /></div>
+          <div style={{ textAlign: 'center' }}><Gauge value={desktop.seo} max={100} label="SEO" goodThreshold={90} needsWorkThreshold={50} /></div>
         </div>
       </div>
       <div className="bp-card" style={{ padding: '16px 18px' }}>
@@ -645,17 +644,17 @@ function PSDesktop({ metrics }) {
 
 // ─── PageSpeed History Tab ────────────────────────────────────────────────────
 
-function PSHistory({ metrics }) {
+function PSHistory({ metrics }: any) {
   const { series } = metrics
-  const mobileSeries = (series['performance_mobile'] || []).map(m => ({
+  const mobileSeries = (series['performance_mobile'] || []).map((m: any) => ({
     date: format(parseISO(m.recorded_at), 'MMM d'),
     mobile: typeof m.metric_value === 'number' ? (m.metric_value <= 1 ? Math.round(m.metric_value * 100) : Math.round(m.metric_value)) : 0,
   }))
-  const desktopSeries = (series['performance_desktop'] || []).map(m => ({
+  const desktopSeries = (series['performance_desktop'] || []).map((m: any) => ({
     date: format(parseISO(m.recorded_at), 'MMM d'),
     desktop: typeof m.metric_value === 'number' ? (m.metric_value <= 1 ? Math.round(m.metric_value * 100) : Math.round(m.metric_value)) : 0,
   }))
-  const merged = mobileSeries.map((m, i) => ({ ...m, desktop: desktopSeries[i]?.desktop }))
+  const merged = mobileSeries.map((m: any, i: any) => ({ ...m, desktop: desktopSeries[i]?.desktop }))
   if (merged.length < 2) return <EmptyState message="Score history builds up after multiple syncs." />
   return (
     <div className="bp-card" style={{ padding: '16px 18px' }}>
@@ -676,7 +675,7 @@ function PSHistory({ metrics }) {
 
 // ─── PageSpeed Opportunities Tab ──────────────────────────────────────────────
 
-function PSOpportunities({ metrics, connector }) {
+function PSOpportunities({ metrics, connector }: any) {
   const addNotification = useStore((s) => s.addNotification)
   const opportunities = (() => {
     // Aliases now expose opportunities_mobile_data + opportunities_desktop_data;
@@ -688,9 +687,9 @@ function PSOpportunities({ metrics, connector }) {
     if (!raw) return []
     try { return typeof raw === 'string' ? JSON.parse(raw) : raw } catch { return [] }
   })()
-  const [creating, setCreating] = React.useState({})
+  const [creating, setCreating] = React.useState<Record<string, boolean>>({})
 
-  async function handleCreateTask(opp) {
+  async function handleCreateTask(opp: any) {
     setCreating(p => ({ ...p, [opp.id]: true }))
     try {
       await createTask({
@@ -704,7 +703,7 @@ function PSOpportunities({ metrics, connector }) {
       })
       addNotification({ type: 'success', title: 'Task created', message: `"Fix: ${opp.title}" added to Dev queue` })
     } catch (err) {
-      addNotification({ type: 'error', message: err.message })
+      addNotification({ type: 'error', message: (err as any).message })
     } finally {
       setCreating(p => ({ ...p, [opp.id]: false }))
     }
@@ -713,7 +712,7 @@ function PSOpportunities({ metrics, connector }) {
   if (!opportunities.length) return <EmptyState message="Run a sync to pull PageSpeed opportunities. Ensure your PageSpeed connector is configured." />
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-      {opportunities.map((opp, i) => {
+      {opportunities.map((opp: any, i: any) => {
         const score = opp.score ?? 1
         const scoreColor = score < 0.5 ? 'var(--bp-red)' : score < 0.9 ? 'var(--bp-amber)' : 'var(--bp-green)'
         return (
@@ -752,7 +751,7 @@ function PSOpportunities({ metrics, connector }) {
 
 // ─── Stripe Overview ──────────────────────────────────────────────────────────
 
-function BrevoOverview({ metrics, summary }) {
+function BrevoOverview({ metrics, summary }: any) {
   const { latest } = metrics
   const totalContacts = latest['total_contacts'] ?? 0
   const campaigns30d = latest['campaigns_sent_30d'] ?? 0
@@ -817,7 +816,7 @@ function BrevoOverview({ metrics, summary }) {
   )
 }
 
-function BrevoContacts({ metrics }) {
+function BrevoContacts({ metrics }: any) {
   const { latest } = metrics
   const totalContacts = latest['total_contacts'] ?? 0
   const lists = Array.isArray(latest['lists_data']) ? latest['lists_data'] : []
@@ -864,7 +863,7 @@ function BrevoContacts({ metrics }) {
   )
 }
 
-function BrevoTransactional({ metrics, summary }) {
+function BrevoTransactional({ metrics, summary }: any) {
   const { latest } = metrics
   const delivered = latest['transactional_delivered_7d'] ?? null
   const bounceRate = latest['transactional_bounce_rate_7d'] ?? null
@@ -890,13 +889,13 @@ function BrevoTransactional({ metrics, summary }) {
   )
 }
 
-function StripeOverview({ metrics }) {
+function StripeOverview({ metrics }: any) {
   const { latest, series } = metrics
   const mrr = latest['mrr'] ?? 0
   const arr = latest['arr'] ?? mrr * 12
   const activeCustomers = latest['active_customers'] ?? latest['active_subscriptions'] ?? 0
   const churnRate = latest['churn_rate'] ?? 0
-  const revSeries = (series['revenue'] || []).map(m => ({
+  const revSeries = (series['revenue'] || []).map((m: any) => ({
     date: format(parseISO(m.recorded_at), 'MMM d'),
     revenue: m.metric_value,
   }))
@@ -934,13 +933,13 @@ function StripeOverview({ metrics }) {
 
 // ─── GitHub Overview ──────────────────────────────────────────────────────────
 
-function GitHubOverview({ metrics }) {
+function GitHubOverview({ metrics }: any) {
   const { latest, series } = metrics
   const openPRs = latest['open_prs'] ?? latest['pull_requests_open'] ?? 0
   const mergedPRs = latest['merged_prs_7d'] ?? latest['merged_prs'] ?? 0
   const openIssues = latest['open_issues'] ?? 0
   const commits = latest['commits_7d'] ?? latest['commits'] ?? 0
-  const commitSeries = (series['commits_7d'] || series['commits'] || []).map(m => ({
+  const commitSeries = (series['commits_7d'] || series['commits'] || []).map((m: any) => ({
     date: format(parseISO(m.recorded_at), 'MMM d'),
     commits: m.metric_value,
   }))
@@ -983,7 +982,7 @@ function GitHubOverview({ metrics }) {
               </tr>
             </thead>
             <tbody>
-              {prs.slice(0, 10).map((pr, i) => (
+              {prs.slice(0, 10).map((pr: any, i: any) => (
                 <tr key={i} style={{ borderBottom: '1px solid rgba(255,255,255,0.04)' }}>
                   <td style={{ padding: '9px 14px', fontFamily: 'var(--bp-font-mono)', fontSize: 11, color: 'var(--bp-text)', maxWidth: 280, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{pr.title}</td>
                   <td style={{ padding: '9px 14px' }}>
@@ -1003,12 +1002,12 @@ function GitHubOverview({ metrics }) {
 
 // ─── Shopify Overview ─────────────────────────────────────────────────────────
 
-function ShopifyOverview({ metrics, range }) {
+function ShopifyOverview({ metrics, range }: any) {
   const { latest } = metrics
   const { start, end } = getRangeBounds(range || '30d')
   const prev = getPrevBounds(range || '30d')
   // Use local date strings to avoid UTC shift (e.g. BST midnight → previous UTC day)
-  const toLocalStr = (d) => `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`
+  const toLocalStr = (d: any) => `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`
   const startStr    = toLocalStr(start)
   const endStr      = toLocalStr(end)
   const prevStartStr = toLocalStr(prev.start)
@@ -1057,13 +1056,14 @@ function ShopifyOverview({ metrics, range }) {
     const d = new Date(o.created_at)
     return d >= start && d <= end
   })
-  const productMap = {}
+  const productMap: Record<string, { title: string; quantity: number; revenue: number }> = {}
   for (const o of rangeOrders) {
     for (const item of (o.items || [])) {
       if (!item.title) continue
       if (!productMap[item.title]) productMap[item.title] = { title: item.title, quantity: 0, revenue: 0 }
-      productMap[item.title].quantity += item.quantity || 0
-      productMap[item.title].revenue += (item.price || 0) * (item.quantity || 0)
+      const pm = productMap[item.title]!
+      pm.quantity += item.quantity || 0
+      pm.revenue += (item.price || 0) * (item.quantity || 0)
     }
   }
   const topProducts = Object.values(productMap).sort((a, b) => b.revenue - a.revenue).slice(0, 10)
@@ -1105,7 +1105,7 @@ function ShopifyOverview({ metrics, range }) {
       {topProducts.length > 0 && (
         <div className="bp-card" style={{ padding: 0, overflow: 'hidden' }}>
           <div style={{ padding: '12px 18px', borderBottom: '1px solid var(--bp-border)', fontFamily: 'var(--bp-font-mono)', fontSize: 9, color: 'var(--bp-text-3)', textTransform: 'uppercase', letterSpacing: '0.08em' }}>
-            Top Products — {RANGE_LABELS[range] || range}
+            Top Products — {(RANGE_LABELS as any)[range] || range}
           </div>
           <table style={{ width: '100%', borderCollapse: 'collapse' }}>
             <thead>
@@ -1116,7 +1116,7 @@ function ShopifyOverview({ metrics, range }) {
               </tr>
             </thead>
             <tbody>
-              {topProducts.slice(0, 10).map((p, i) => (
+              {topProducts.slice(0, 10).map((p: any, i) => (
                 <tr key={i} style={{ borderBottom: '1px solid rgba(255,255,255,0.04)' }}>
                   <td style={{ padding: '9px 16px', fontFamily: 'var(--bp-font-mono)', fontSize: 11, color: 'var(--bp-text)', maxWidth: 300, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.title || p.name}</td>
                   <td style={{ padding: '9px 16px', fontFamily: 'var(--bp-font-mono)', fontSize: 11, color: 'var(--bp-text-2)' }}>{(p.units || p.quantity || 0).toLocaleString()}</td>
@@ -1133,7 +1133,7 @@ function ShopifyOverview({ metrics, range }) {
 
 // ─── Shopify Orders Tab ───────────────────────────────────────────────────────
 
-function ShopifyOrders({ metrics, range }) {
+function ShopifyOrders({ metrics, range }: any) {
   const { start, end } = getRangeBounds(range || '30d')
   const allOrders = Array.isArray(metrics.latest['recent_orders_data'])
     ? metrics.latest['recent_orders_data']
@@ -1141,7 +1141,7 @@ function ShopifyOrders({ metrics, range }) {
       ? (typeof metrics.latest['recent_orders_data'] === 'string' ? JSON.parse(metrics.latest['recent_orders_data']) : metrics.latest['recent_orders_data'])
       : []
 
-  const orders = allOrders.filter(o => {
+  const orders = allOrders.filter((o: any) => {
     if (!o.created_at) return true
     const d = new Date(o.created_at)
     return d >= start && d <= end
@@ -1163,7 +1163,7 @@ function ShopifyOrders({ metrics, range }) {
     pending:     { bg: 'var(--bp-text-3)', text: '#fff' },
   }
 
-  const counts = orders.reduce((acc, o) => {
+  const counts = orders.reduce((acc: any, o: any) => {
     const s = (o.fulfillment_status || o.status || 'pending').toLowerCase()
     acc[s] = (acc[s] || 0) + 1
     return acc
@@ -1174,7 +1174,7 @@ function ShopifyOrders({ metrics, range }) {
       {/* Summary pills */}
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
         {Object.entries(counts).map(([status, count]) => {
-          const c = statusColors[status] || { bg: 'var(--bp-text-3)', text: '#fff' }
+          const c = (statusColors as any)[status] || { bg: 'var(--bp-text-3)', text: '#fff' }
           return (
             <span key={status} style={{
               display: 'inline-flex', alignItems: 'center', gap: 5,
@@ -1184,7 +1184,7 @@ function ShopifyOrders({ metrics, range }) {
               textTransform: 'capitalize',
             }}>
               <span style={{ width: 6, height: 6, borderRadius: '50%', background: c.bg, display: 'inline-block' }} />
-              {status}: {count}
+              {status}: {count as any}
             </span>
           )
         })}
@@ -1201,9 +1201,9 @@ function ShopifyOrders({ metrics, range }) {
             </tr>
           </thead>
           <tbody>
-            {orders.map((o, i) => {
+            {orders.map((o: any, i: any) => {
               const rawStatus = (o.fulfillment_status || o.status || 'pending').toLowerCase()
-              const c = statusColors[rawStatus] || { bg: 'var(--bp-text-3)', text: '#fff' }
+              const c = (statusColors as any)[rawStatus] || { bg: 'var(--bp-text-3)', text: '#fff' }
               const dateStr = o.created_at ? (() => { try { return format(parseISO(o.created_at), 'MMM d, yyyy') } catch { return o.created_at } })() : '—'
               const customerName = typeof o.customer === 'string' ? (o.customer || '—') : (o.customer_name || o.email || '—')
               const itemCount = o.item_count || o.items_count || (o.line_items ? o.line_items.length : 0)
@@ -1237,7 +1237,7 @@ function ShopifyOrders({ metrics, range }) {
 
 // ─── Shopify Products Tab ─────────────────────────────────────────────────────
 
-function ShopifyProducts({ metrics }) {
+function ShopifyProducts({ metrics }: any) {
   const [view, setView] = useState('table')
   const products = metrics.latest['products_data']
     ? (typeof metrics.latest['products_data'] === 'string'
@@ -1284,7 +1284,7 @@ function ShopifyProducts({ metrics }) {
               </tr>
             </thead>
             <tbody>
-              {products.slice(0, 200).map((p, i) => {
+              {products.slice(0, 200).map((p: any, i: any) => {
                 const isActive = (p.status || 'active').toLowerCase() === 'active'
                 const priceDisplay = p.price ? `£${Number(p.price).toFixed(2)}` : '—'
                 const invDisplay = p.inventory === null || p.inventory === undefined
@@ -1309,7 +1309,7 @@ function ShopifyProducts({ metrics }) {
         </div>
       ) : (
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))', gap: 12 }}>
-          {products.slice(0, 100).map((p, i) => {
+          {products.slice(0, 100).map((p: any, i: any) => {
             const isActive = (p.status || 'active').toLowerCase() === 'active'
             const priceDisplay = p.price ? `£${Number(p.price).toFixed(2)}` : '—'
             const inv = p.inventory
@@ -1340,7 +1340,7 @@ function ShopifyProducts({ metrics }) {
 
 // ─── Shopify Customers Tab ────────────────────────────────────────────────────
 
-function ShopifyCustomers({ metrics, range }) {
+function ShopifyCustomers({ metrics, range }: any) {
   const { start } = getRangeBounds(range || '30d')
 
   const allRows = Array.isArray(metrics.latest['customers_data'])
@@ -1351,7 +1351,7 @@ function ShopifyCustomers({ metrics, range }) {
 
   const totalCustomers = metrics.latest['customers'] ?? 0
   // New customers = joined within the selected range
-  const newInPeriod = allRows.filter(c => c.created_at && new Date(c.created_at) >= start).length
+  const newInPeriod = allRows.filter((c: any) => c.created_at && new Date(c.created_at) >= start).length
 
   const rows = allRows
 
@@ -1364,8 +1364,8 @@ function ShopifyCustomers({ metrics, range }) {
       {/* Summary metrics */}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12 }}>
         <MetricCard label="Total Customers" value={totalCustomers} accent="var(--bp-purple)" />
-        <MetricCard label={`New in ${RANGE_LABELS[range] || range}`} value={newInPeriod} accent="var(--bp-green)" />
-        <MetricCard label="Avg Spend" value={rows.length ? rows.reduce((s, c) => s + (c.total_spent || 0), 0) / rows.length : 0} format="currency" accent="var(--bp-cyan)" />
+        <MetricCard label={`New in ${(RANGE_LABELS as any)[range] || range}`} value={newInPeriod} accent="var(--bp-green)" />
+        <MetricCard label="Avg Spend" value={rows.length ? rows.reduce((s: any, c: any) => s + (c.total_spent || 0), 0) / rows.length : 0} format="currency" accent="var(--bp-cyan)" />
       </div>
 
       {/* Customers table */}
@@ -1379,7 +1379,7 @@ function ShopifyCustomers({ metrics, range }) {
             </tr>
           </thead>
           <tbody>
-            {rows.slice(0, 100).map((c, i) => {
+            {rows.slice(0, 100).map((c: any, i: any) => {
               const name = c.name || `${c.first_name || ''} ${c.last_name || ''}`.trim() || '—'
               const isNew = c.created_at && new Date(c.created_at) >= start
               const lastOrder = c.last_order_date || c.updated_at
@@ -1406,7 +1406,7 @@ function ShopifyCustomers({ metrics, range }) {
 
 // ─── Shopify Inventory Tab ────────────────────────────────────────────────────
 
-function ShopifyInventory({ metrics }) {
+function ShopifyInventory({ metrics }: any) {
   const inventoryData = metrics.latest['inventory_data']
     ? (typeof metrics.latest['inventory_data'] === 'string'
         ? JSON.parse(metrics.latest['inventory_data'])
@@ -1419,12 +1419,12 @@ function ShopifyInventory({ metrics }) {
     return <EmptyState message="Inventory data will appear here after sync." />
   }
 
-  const getQty = (r) => parseInt(r.inventory ?? r.available ?? r.quantity ?? r.inventory_quantity ?? 0)
+  const getQty = (r: any) => parseInt(r.inventory ?? r.available ?? r.quantity ?? r.inventory_quantity ?? 0)
 
-  const lowStock = rows.filter(r => getQty(r) < 10)
-    .sort((a, b) => getQty(a) - getQty(b))
+  const lowStock = rows.filter((r: any) => getQty(r) < 10)
+    .sort((a: any, b: any) => getQty(a) - getQty(b))
 
-  const getStatus = (qty) => {
+  const getStatus = (qty: any) => {
     if (qty <= 0)  return { label: 'Out of Stock', color: 'var(--bp-red)' }
     if (qty < 5)   return { label: 'Critical',     color: 'var(--bp-red)' }
     if (qty < 10)  return { label: 'Low Stock',    color: 'var(--bp-amber)' }
@@ -1440,7 +1440,7 @@ function ShopifyInventory({ metrics }) {
             Low Stock Alerts ({lowStock.length})
           </div>
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))', gap: 10 }}>
-            {lowStock.slice(0, 12).map((item, i) => {
+            {lowStock.slice(0, 12).map((item: any, i: any) => {
               const qty = getQty(item)
               const status = getStatus(qty)
               return (
@@ -1482,7 +1482,7 @@ function ShopifyInventory({ metrics }) {
             </tr>
           </thead>
           <tbody>
-            {rows.slice(0, 200).map((item, i) => {
+            {rows.slice(0, 200).map((item: any, i: any) => {
               const qty = getQty(item)
               const status = getStatus(qty)
               return (
@@ -1520,7 +1520,7 @@ function ShopifyInventory({ metrics }) {
 
 // ─── GA4 Pages Tab ────────────────────────────────────────────────────────────
 
-function GA4Pages({ metrics }) {
+function GA4Pages({ metrics }: any) {
   const raw = metrics.latest['top_pages_data']
     ?? metrics.latest['pages_data']
     ?? (Array.isArray(metrics.latest['top_pages']) ? metrics.latest['top_pages'] : null)
@@ -1587,7 +1587,7 @@ const CHANNEL_COLORS = {
   'Unassigned':     '#666',
 }
 
-function GA4Acquisition({ metrics }) {
+function GA4Acquisition({ metrics }: any) {
   const raw = metrics.latest['traffic_sources_data']
     ?? metrics.latest['acquisition_data']
     ?? (Array.isArray(metrics.latest['traffic_sources']) ? metrics.latest['traffic_sources'] : null)
@@ -1632,7 +1632,7 @@ function GA4Acquisition({ metrics }) {
             <Tooltip content={<CustomTooltip />} />
             <Bar dataKey="sessions" name="Sessions" radius={[0, 2, 2, 0]}>
               {chartData.map((entry, index) => (
-                <Cell key={index} fill={CHANNEL_COLORS[entry.name] || CHART_COLORS.blue} />
+                <Cell key={index} fill={(CHANNEL_COLORS as any)[entry.name] || CHART_COLORS.blue} />
               ))}
             </Bar>
           </BarChart>
@@ -1656,7 +1656,7 @@ function GA4Acquisition({ metrics }) {
               const users = c.users || 0
               const share = totalSessions > 0 ? (sessions / totalSessions) * 100 : 0
               const bounceRate = c.bounceRate || c.bounce_rate || 0
-              const dotColor = CHANNEL_COLORS[channelName] || CHART_COLORS.blue
+              const dotColor = (CHANNEL_COLORS as any)[channelName] || CHART_COLORS.blue
               return (
                 <tr key={i} style={{ borderBottom: '1px solid rgba(255,255,255,0.04)' }}>
                   <td style={{ padding: '9px 16px' }}>
@@ -1690,7 +1690,7 @@ function GA4Acquisition({ metrics }) {
 
 // ─── Empty State ──────────────────────────────────────────────────────────────
 
-function EmptyState({ message = 'No data available yet. Run a sync to pull data.' }) {
+function EmptyState({ message = 'No data available yet. Run a sync to pull data.' }: any) {
   return (
     <div style={{
       display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
@@ -1705,25 +1705,25 @@ function EmptyState({ message = 'No data available yet. Run a sync to pull data.
 
 // ─── Meta Ads tabs ────────────────────────────────────────────────────────────
 
-function metaNum(metrics, name) {
-  const row = metrics?.find(m => m.metric_name === name)
+function metaNum(metrics: any, name: any) {
+  const row = metrics?.find((m: any) => m.metric_name === name)
   return row?.metric_value != null ? Number(row.metric_value) : 0
 }
-function metaData(metrics, name) {
-  const row = metrics?.find(m => m.metric_name === name)
+function metaData(metrics: any, name: any) {
+  const row = metrics?.find((m: any) => m.metric_name === name)
   if (!row?.metric_data) return null
   try { return typeof row.metric_data === 'string' ? JSON.parse(row.metric_data) : row.metric_data }
   catch { return null }
 }
-function fmtCurrency(n, ccy = '£') {
+function fmtCurrency(n: any, ccy: any = '£') {
   const num = Number(n) || 0
   return `${ccy}${num.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
 }
-function fmtInt(n) {
+function fmtInt(n: any) {
   return Math.round(Number(n) || 0).toLocaleString('en-GB')
 }
 
-function MetaAdsOverview({ metrics }) {
+function MetaAdsOverview({ metrics }: any) {
   const spend      = metaNum(metrics, 'meta-ads.spend_30d')
   const revenue    = metaNum(metrics, 'meta-ads.revenue_30d')
   const roas       = metaNum(metrics, 'meta-ads.roas')
@@ -1790,7 +1790,7 @@ function MetaAdsOverview({ metrics }) {
   )
 }
 
-function MetaAdsCampaigns({ metrics }) {
+function MetaAdsCampaigns({ metrics }: any) {
   const campaigns = metaData(metrics, 'meta-ads.campaigns_data') ?? []
   if (campaigns.length === 0) return <EmptyState message="No campaign data available yet. Sync the connector to pull the last 30 days of performance." />
   const sorted = [...campaigns].sort((a, b) => (b.spend ?? 0) - (a.spend ?? 0))
@@ -1829,7 +1829,7 @@ function MetaAdsCampaigns({ metrics }) {
 
 // ─── Tab content router ───────────────────────────────────────────────────────
 
-function renderTab(connector, tab, data, range) {
+function renderTab(connector: any, tab: any, data: any, range: any) {
   const { type } = connector
   const { metrics, summary } = data
 
@@ -1929,7 +1929,7 @@ function renderTab(connector, tab, data, range) {
 
 // Small table cell helpers used across the new connector tabs. Kept local
 // to this file; consistent with existing inline-styled tables elsewhere.
-function Th({ children, align = 'left' }) {
+function Th({ children, align = 'left' }: any) {
   return (
     <th style={{
       textAlign: align, padding: '10px 12px', fontWeight: 600,
@@ -1940,7 +1940,7 @@ function Th({ children, align = 'left' }) {
     </th>
   )
 }
-function Td({ children, align = 'left', style }) {
+function Td({ children, align = 'left', style }: any) {
   return (
     <td style={{
       textAlign: align, padding: '9px 12px', color: 'var(--bp-text-2)',
@@ -1951,19 +1951,19 @@ function Td({ children, align = 'left', style }) {
   )
 }
 
-function num(v, fallback = 0) {
+function num(v: any, fallback: any = 0) {
   if (v === null || v === undefined) return fallback
   const n = typeof v === 'number' ? v : parseFloat(v)
   return Number.isFinite(n) ? n : fallback
 }
 
-function latestValue(metrics, key) {
+function latestValue(metrics: any, key: any) {
   return num(metrics?.latest?.[key] ?? null)
 }
 
-function latestData(metrics, key) {
+function latestData(metrics: any, key: any) {
   const m = metrics?.series?.[key] ?? []
-  const withData = m.find(r => r.metric_data)
+  const withData = m.find((r: any) => r.metric_data)
   if (!withData) return null
   try {
     return typeof withData.metric_data === 'string'
@@ -1972,7 +1972,7 @@ function latestData(metrics, key) {
   } catch { return null }
 }
 
-function KlaviyoOverview({ metrics }) {
+function KlaviyoOverview({ metrics }: any) {
   const attributed = latestValue(metrics, 'klaviyo.total_attributed_revenue_30d')
   const perEmail = latestValue(metrics, 'klaviyo.revenue_per_email_sent')
   const subs = latestValue(metrics, 'klaviyo.total_subscribers')
@@ -2019,7 +2019,7 @@ function KlaviyoOverview({ metrics }) {
   )
 }
 
-function KlaviyoCampaigns({ metrics }) {
+function KlaviyoCampaigns({ metrics }: any) {
   const rows = latestData(metrics, 'klaviyo.campaigns_data') ?? []
   if (!rows.length) return <EmptyState message="No campaigns in the last 30 days." />
   const sorted = [...rows].sort((a, b) => (b.revenue || 0) - (a.revenue || 0))
@@ -2044,7 +2044,7 @@ function KlaviyoCampaigns({ metrics }) {
   )
 }
 
-function KlaviyoFlows({ metrics }) {
+function KlaviyoFlows({ metrics }: any) {
   const rows = latestData(metrics, 'klaviyo.flows_data') ?? []
   if (!rows.length) return <EmptyState message="No live flows detected." />
   return (
@@ -2053,7 +2053,7 @@ function KlaviyoFlows({ metrics }) {
         <thead><tr style={{ background: 'var(--bp-surface-2)' }}>
           <Th>Flow</Th><Th>Class</Th><Th>Status</Th><Th align="right">Recipients</Th><Th align="right">Revenue (30d)</Th><Th align="right">£ / Recipient</Th>
         </tr></thead>
-        <tbody>{rows.map((f, i) => (
+        <tbody>{rows.map((f: any, i: any) => (
           <tr key={f.id || i} style={{ borderBottom: '1px solid var(--bp-border)', background: f.class === 'abandoned_cart' && (f.revenue || 0) > 0 ? 'rgba(0,201,167,0.05)' : 'transparent' }}>
             <Td><strong>{f.name}</strong></Td>
             <Td>{f.class || '—'}</Td>
@@ -2068,14 +2068,14 @@ function KlaviyoFlows({ metrics }) {
   )
 }
 
-function KlaviyoLists({ metrics }) {
+function KlaviyoLists({ metrics }: any) {
   const rows = latestData(metrics, 'klaviyo.lists_data') ?? []
   if (!rows.length) return <EmptyState message="No lists found." />
   return (
     <div className="bp-card" style={{ padding: 0, overflow: 'hidden' }}>
       <table style={{ width: '100%', borderCollapse: 'collapse', fontFamily: 'var(--bp-font-mono)', fontSize: 11 }}>
         <thead><tr style={{ background: 'var(--bp-surface-2)' }}><Th>List</Th><Th align="right">Subscribers</Th><Th>Opt-in</Th><Th>Created</Th></tr></thead>
-        <tbody>{rows.map((l, i) => (
+        <tbody>{rows.map((l: any, i: any) => (
           <tr key={l.id || i} style={{ borderBottom: '1px solid var(--bp-border)' }}>
             <Td><strong>{l.name}</strong></Td>
             <Td align="right">{(l.profile_count || 0).toLocaleString()}</Td>
@@ -2088,7 +2088,7 @@ function KlaviyoLists({ metrics }) {
   )
 }
 
-function SemrushOverview({ metrics }) {
+function SemrushOverview({ metrics }: any) {
   const rank = latestValue(metrics, 'semrush.domain_rank')
   const keywords = latestValue(metrics, 'semrush.organic_keywords_total')
   const traffic = latestValue(metrics, 'semrush.organic_traffic_estimate')
@@ -2136,7 +2136,7 @@ function SemrushOverview({ metrics }) {
   )
 }
 
-function SemrushKeywords({ metrics }) {
+function SemrushKeywords({ metrics }: any) {
   const rows = latestData(metrics, 'semrush.top_keywords_data') ?? []
   if (!rows.length) return <EmptyState message="No keyword data yet. Sync the connector." />
   return (
@@ -2145,7 +2145,7 @@ function SemrushKeywords({ metrics }) {
         <thead><tr style={{ background: 'var(--bp-surface-2)', position: 'sticky', top: 0 }}>
           <Th>Keyword</Th><Th align="right">Pos</Th><Th align="right">Δ</Th><Th align="right">Volume</Th><Th align="right">Traffic</Th><Th>URL</Th>
         </tr></thead>
-        <tbody>{rows.map((k, i) => {
+        <tbody>{rows.map((k: any, i: any) => {
           const diff = Number(k.position_difference) || 0
           const diffColor = diff < 0 ? 'var(--bp-green)' : diff > 0 ? 'var(--bp-red)' : 'var(--bp-text-3)'
           return (
@@ -2164,7 +2164,7 @@ function SemrushKeywords({ metrics }) {
   )
 }
 
-function SemrushCompetitors({ metrics }) {
+function SemrushCompetitors({ metrics }: any) {
   const rows = latestData(metrics, 'semrush.competitors_data') ?? []
   if (!rows.length) return <EmptyState message="No competitor data yet." />
   return (
@@ -2173,7 +2173,7 @@ function SemrushCompetitors({ metrics }) {
         <thead><tr style={{ background: 'var(--bp-surface-2)' }}>
           <Th>Domain</Th><Th align="right">Shared Keywords</Th><Th align="right">Their Keywords</Th><Th align="right">Their Traffic</Th>
         </tr></thead>
-        <tbody>{rows.map((c, i) => (
+        <tbody>{rows.map((c: any, i: any) => (
           <tr key={i} style={{ borderBottom: '1px solid var(--bp-border)' }}>
             <Td><strong>{c.domain}</strong></Td>
             <Td align="right">{(Number(c.shared_keywords) || 0).toLocaleString()}</Td>
@@ -2186,7 +2186,7 @@ function SemrushCompetitors({ metrics }) {
   )
 }
 
-function SemrushOpportunities({ metrics }) {
+function SemrushOpportunities({ metrics }: any) {
   const rows = latestData(metrics, 'semrush.opportunities_data') ?? []
   if (!rows.length) return <EmptyState message="No page-2 opportunities — either no data yet or all keywords already on page 1." />
   return (
@@ -2199,7 +2199,7 @@ function SemrushOpportunities({ metrics }) {
           <thead><tr style={{ background: 'var(--bp-surface-2)' }}>
             <Th>Keyword</Th><Th align="right">Position</Th><Th align="right">Search Volume</Th><Th>Current URL</Th>
           </tr></thead>
-          <tbody>{rows.map((k, i) => (
+          <tbody>{rows.map((k: any, i: any) => (
             <tr key={i} style={{ borderBottom: '1px solid var(--bp-border)' }}>
               <Td><strong>{k.keyword}</strong></Td>
               <Td align="right">{Math.round(Number(k.position) || 0)}</Td>
@@ -2213,7 +2213,7 @@ function SemrushOpportunities({ metrics }) {
   )
 }
 
-function SocialOverview({ metrics }) {
+function SocialOverview({ metrics }: any) {
   const fbFollowers = latestValue(metrics, 'fb.page_followers')
   const fbReach = latestValue(metrics, 'fb.page_reach_30d')
   const fbEngRate = latestValue(metrics, 'fb.page_engagement_rate') * 100
@@ -2247,12 +2247,12 @@ function SocialOverview({ metrics }) {
   )
 }
 
-function SocialPosts({ metrics }) {
+function SocialPosts({ metrics }: any) {
   const fb = latestData(metrics, 'fb.recent_posts_data') ?? []
   const ig = latestData(metrics, 'ig.recent_posts_data') ?? []
   const combined = [
-    ...fb.map(p => ({ platform: 'facebook', text: p.message, reach: p.reach, engagement: p.engaged_users, date: p.created_time, url: p.permalink_url })),
-    ...ig.map(p => ({ platform: 'instagram', text: p.caption, reach: p.reach, engagement: (p.likes || 0) + (p.comments || 0) + (p.saved || 0), date: p.timestamp, url: p.permalink })),
+    ...fb.map((p: any) => ({ platform: 'facebook', text: p.message, reach: p.reach, engagement: p.engaged_users, date: p.created_time, url: p.permalink_url })),
+    ...ig.map((p: any) => ({ platform: 'instagram', text: p.caption, reach: p.reach, engagement: (p.likes || 0) + (p.comments || 0) + (p.saved || 0), date: p.timestamp, url: p.permalink })),
   ].sort((a, b) => (b.reach || 0) - (a.reach || 0))
   if (!combined.length) return <EmptyState message="No posts synced yet." />
   return (
@@ -2279,7 +2279,7 @@ function SocialPosts({ metrics }) {
   )
 }
 
-function BufferOverview({ metrics }) {
+function BufferOverview({ metrics }: any) {
   const profiles = latestValue(metrics, 'buffer.profiles_connected')
   const published = latestValue(metrics, 'buffer.posts_published_30d')
   const pending = latestValue(metrics, 'buffer.posts_scheduled_pending')
@@ -2303,14 +2303,14 @@ function BufferOverview({ metrics }) {
   )
 }
 
-function BufferQueue({ metrics }) {
+function BufferQueue({ metrics }: any) {
   const rows = latestData(metrics, 'buffer.scheduled_queue') ?? []
   if (!rows.length) return <EmptyState message="No posts scheduled." />
   return (
     <div className="bp-card" style={{ padding: 0, overflow: 'hidden' }}>
       <table style={{ width: '100%', borderCollapse: 'collapse', fontFamily: 'var(--bp-font-mono)', fontSize: 11 }}>
         <thead><tr style={{ background: 'var(--bp-surface-2)' }}><Th>Platform</Th><Th>Scheduled</Th><Th>Post</Th></tr></thead>
-        <tbody>{rows.map((u, i) => (
+        <tbody>{rows.map((u: any, i: any) => (
           <tr key={u.id || i} style={{ borderBottom: '1px solid var(--bp-border)' }}>
             <Td>{u.service}</Td>
             <Td>{u.scheduled_at_iso ? format(parseISO(u.scheduled_at_iso), 'MMM d HH:mm') : '—'}</Td>
@@ -2322,7 +2322,7 @@ function BufferQueue({ metrics }) {
   )
 }
 
-function BufferRecentPosts({ metrics }) {
+function BufferRecentPosts({ metrics }: any) {
   const rows = latestData(metrics, 'buffer.recent_posts_data') ?? []
   if (!rows.length) return <EmptyState message="No recent posts." />
   const sorted = [...rows].sort((a, b) => (b.engagement || 0) - (a.engagement || 0))
@@ -2349,7 +2349,7 @@ function BufferRecentPosts({ metrics }) {
 
 // ─── Wix tabs ───────────────────────────────────────────────────────────────
 
-function WixOverview({ metrics }) {
+function WixOverview({ metrics }: any) {
   const totalPages = latestValue(metrics, 'wix.total_pages')
   const posts = latestValue(metrics, 'wix.blog_posts_total')
   const score = latestValue(metrics, 'wix.seo_score')
@@ -2387,7 +2387,7 @@ function WixOverview({ metrics }) {
   )
 }
 
-function WixPages({ metrics }) {
+function WixPages({ metrics }: any) {
   const audit = latestData(metrics, 'wix.seo_audit_data') ?? []
   if (!audit.length) return <EmptyState message="No pages synced yet." />
   return (
@@ -2396,7 +2396,7 @@ function WixPages({ metrics }) {
         <thead><tr style={{ background: 'var(--bp-surface-2)' }}>
           <Th>Page</Th><Th>URL</Th><Th>SEO Title</Th><Th>Meta Desc</Th><Th>Indexed</Th><Th align="right">Score</Th>
         </tr></thead>
-        <tbody>{audit.map((p, i) => (
+        <tbody>{audit.map((p: any, i: any) => (
           <tr key={p.pageId || i} style={{ borderBottom: '1px solid var(--bp-border)',
             background: p.score < 60 ? 'rgba(255,82,82,0.05)' : 'transparent' }}>
             <Td><strong>{p.pageTitle}</strong></Td>
@@ -2412,7 +2412,7 @@ function WixPages({ metrics }) {
   )
 }
 
-function WixBlog({ metrics }) {
+function WixBlog({ metrics }: any) {
   const posts = latestData(metrics, 'wix.posts_data') ?? []
   if (!posts.length) return <EmptyState message="No blog posts found." />
   return (
@@ -2421,7 +2421,7 @@ function WixBlog({ metrics }) {
         <thead><tr style={{ background: 'var(--bp-surface-2)' }}>
           <Th>Title</Th><Th>Published</Th><Th>Status</Th><Th>SEO</Th>
         </tr></thead>
-        <tbody>{posts.map((p, i) => {
+        <tbody>{posts.map((p: any, i: any) => {
           const seo = p.seo ?? {}
           const hasSeo = !!(seo.title && seo.description)
           return (
@@ -2438,7 +2438,7 @@ function WixBlog({ metrics }) {
   )
 }
 
-function WixSeoAudit({ metrics }) {
+function WixSeoAudit({ metrics }: any) {
   const audit = latestData(metrics, 'wix.seo_audit_data') ?? []
   if (!audit.length) return <EmptyState message="No SEO audit data yet." />
   const worst = [...audit].sort((a, b) => a.score - b.score)
@@ -2461,7 +2461,7 @@ function WixSeoAudit({ metrics }) {
           </div>
           {p.issues.length > 0 ? (
             <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', fontFamily: 'var(--bp-font-mono)', fontSize: 9 }}>
-              {p.issues.map((issue, j) => (
+              {p.issues.map((issue: any, j: any) => (
                 <span key={j} style={{
                   padding: '2px 6px', borderRadius: 3,
                   background: 'rgba(245,158,11,0.15)', color: 'var(--bp-amber)',
@@ -2481,7 +2481,7 @@ function WixSeoAudit({ metrics }) {
 
 // ─── Server-access tabs ─────────────────────────────────────────────────────
 
-function ServerAccessOverview({ connector, metrics }) {
+function ServerAccessOverview({ connector, metrics }: any) {
   const phpErrors = latestValue(metrics, 'server.php_errors_24h')
   const fatalErrors = latestValue(metrics, 'server.php_fatal_errors_24h')
   const disk = latestValue(metrics, 'server.disk_usage_pct')
@@ -2520,10 +2520,10 @@ function ServerAccessOverview({ connector, metrics }) {
   )
 }
 
-function ServerAccessFileExplorer({ metrics }) {
+function ServerAccessFileExplorer({ metrics }: any) {
   const files = latestData(metrics, 'server.site_structure') ?? []
   if (!files.length) return <EmptyState message="No files indexed yet. Trigger a sync." />
-  const grouped = {}
+  const grouped: Record<string, any[]> = {}
   for (const f of files) {
     const parts = f.path.split('/')
     const dir = parts.slice(0, -1).join('/')
@@ -2538,8 +2538,8 @@ function ServerAccessFileExplorer({ metrics }) {
         </tr></thead>
         <tbody>{Object.entries(grouped).map(([dir, groupFiles]) => (
           <React.Fragment key={dir}>
-            <tr><Td colSpan="3" style={{ background: 'var(--bp-surface-2)', fontWeight: 700, color: 'var(--bp-text-3)' }}>{dir || '/'}</Td></tr>
-            {groupFiles.map((f, i) => (
+            <tr><td colSpan={3} style={{ background: 'var(--bp-surface-2)', fontWeight: 700, color: 'var(--bp-text-3)', padding: '9px 12px' }}>{dir || '/'}</td></tr>
+            {groupFiles.map((f: any, i: any) => (
               <tr key={f.path} style={{ borderBottom: '1px solid var(--bp-border)' }}>
                 <Td style={{ paddingLeft: 28 }}>{f.name}</Td>
                 <Td align="right">{(f.size / 1024).toFixed(1)} KB</Td>
@@ -2553,7 +2553,7 @@ function ServerAccessFileExplorer({ metrics }) {
   )
 }
 
-function ServerAccessErrorLog({ metrics }) {
+function ServerAccessErrorLog({ metrics }: any) {
   const entries = latestData(metrics, 'server.recent_errors') ?? []
   if (!entries.length) return <EmptyState message="No server errors found (or error log not accessible)." />
   const TYPE_COLORS = {
@@ -2568,9 +2568,9 @@ function ServerAccessErrorLog({ metrics }) {
         <thead><tr style={{ background: 'var(--bp-surface-2)', position: 'sticky', top: 0 }}>
           <Th>Type</Th><Th>Timestamp</Th><Th>Message</Th>
         </tr></thead>
-        <tbody>{entries.map((e, i) => (
+        <tbody>{entries.map((e: any, i: any) => (
           <tr key={i} style={{ borderBottom: '1px solid var(--bp-border)' }}>
-            <Td><span style={{ color: TYPE_COLORS[e.type] || 'var(--bp-text-3)', fontWeight: 600, textTransform: 'uppercase' }}>{e.type}</span></Td>
+            <Td><span style={{ color: (TYPE_COLORS as any)[e.type] || 'var(--bp-text-3)', fontWeight: 600, textTransform: 'uppercase' }}>{e.type}</span></Td>
             <Td>{e.timestamp || '—'}</Td>
             <Td style={{ maxWidth: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{e.line}</Td>
           </tr>
@@ -2580,11 +2580,11 @@ function ServerAccessErrorLog({ metrics }) {
   )
 }
 
-function ServerAccessChanges({ connector }) {
+function ServerAccessChanges({ connector }: any) {
   // Lists every file_write Blueprint has performed via this connector.
   // Each row shows the resulting backup id so the user can trigger a
   // rollback task.
-  const [changes, setChanges] = useState([])
+  const [changes, setChanges] = useState<any[]>([])
   useEffect(() => {
     if (!connector?.id) return
     fetch(`/api/connectors/${connector.id}/file-changes`, { credentials: 'include' })
@@ -2612,7 +2612,7 @@ function ServerAccessChanges({ connector }) {
   )
 }
 
-function ServerAccessBackups({ connector }) {
+function ServerAccessBackups({ connector }: any) {
   return <ServerAccessChanges connector={connector} />
 }
 
@@ -2626,21 +2626,21 @@ function ConnectorDataPage() {
 
   const range = searchParams.get('range') || 'today'
   const [activeTab, setActiveTab] = useState(null)
-  const [data, setData] = useState(null)
+  const [data, setData] = useState<any>(null)
   const [loading, setLoading] = useState(true)
   const [syncing, setSyncing] = useState(false)
 
   const fetchData = useCallback(async () => {
     setLoading(true)
     try {
-      const result = await getConnectorData(connectorId, { range })
+      const result = await getConnectorData(connectorId!, { range })
       setData(result)
       if (!activeTab) {
-        const tabs = CONNECTOR_TABS[result?.connector?.type] || CONNECTOR_TABS.default
+        const tabs = (CONNECTOR_TABS as any)[result?.connector?.type] || CONNECTOR_TABS.default
         setActiveTab(tabs[0])
       }
     } catch (err) {
-      addNotification({ type: 'error', message: 'Failed to load connector data: ' + err.message })
+      addNotification({ type: 'error', message: 'Failed to load connector data: ' + (err as any).message })
     } finally { setLoading(false) }
   }, [connectorId, range])
 
@@ -2649,15 +2649,15 @@ function ConnectorDataPage() {
   async function handleSync() {
     setSyncing(true)
     try {
-      await syncConnector(connectorId)
+      await syncConnector(connectorId!)
       addNotification({ type: 'success', message: 'Sync started' })
       setTimeout(fetchData, 3000)
     } catch (err) {
-      addNotification({ type: 'error', message: err.message })
+      addNotification({ type: 'error', message: (err as any).message })
     } finally { setSyncing(false) }
   }
 
-  function setRange(r) {
+  function setRange(r: any) {
     setSearchParams({ range: r }, { replace: true })
   }
 
@@ -2693,9 +2693,9 @@ function ConnectorDataPage() {
   }
 
   const { connector } = data
-  const meta = CONNECTOR_META[connector.type] || CONNECTOR_META.default
+  const meta = (CONNECTOR_META as any)[connector.type] || CONNECTOR_META.default
   const Icon = meta.icon
-  const tabs = CONNECTOR_TABS[connector.type] || CONNECTOR_TABS.default
+  const tabs = (CONNECTOR_TABS as any)[connector.type] || CONNECTOR_TABS.default
   const currentTab = activeTab || tabs[0]
 
   const statusDotClass = connector.status === 'connected' ? 'pulse-dot-green'
@@ -2758,7 +2758,7 @@ function ConnectorDataPage() {
                   transition: 'all 120ms ease',
                 }}
               >
-                {RANGE_LABELS[r] || r}
+                {(RANGE_LABELS as any)[r] || r}
               </button>
             ))}
           </div>
@@ -2780,7 +2780,7 @@ function ConnectorDataPage() {
         display: 'flex', gap: 0, marginBottom: 20,
         borderBottom: '1px solid var(--bp-border)',
       }}>
-        {tabs.map((tab) => (
+        {tabs.map((tab: any) => (
           <button
             key={tab}
             onClick={() => setActiveTab(tab)}

--- a/client/src/pages/Goals.tsx
+++ b/client/src/pages/Goals.tsx
@@ -70,7 +70,9 @@ function fmtRel(iso: string | undefined | null) {
 
 function daysUntil(iso: string | undefined | null) {
   if (!iso) return null
-  return Math.ceil((new Date(iso).getTime() - new Date().getTime()) / 86400000)
+  const d = parseTimestamp(iso)
+  if (!d) return null
+  return Math.ceil((d.getTime() - Date.now()) / 86400000)
 }
 
 function GoalCard({ goal, businessId, onRefresh }: { goal: Goal; businessId: string; onRefresh: () => void }) {

--- a/server/connectors/gbp/index.ts
+++ b/server/connectors/gbp/index.ts
@@ -142,18 +142,29 @@ const connector = {
 
     // Run all reads in parallel — each catches its own errors so one failure
     // doesn't sink the whole sync (legacy API endpoints can be flaky).
+    // Failed sections are logged and reported in `partial_failures` so the
+    // sync layer and dashboard can tell "no reviews" apart from "reviews
+    // fetch failed".
+    const partialFailures: Array<{ section: string; error: string }> = [];
+    const fallback = <T>(section: string, value: T) => (err: unknown): T => {
+      const message = err instanceof Error ? err.message : String(err);
+      partialFailures.push({ section, error: message.substring(0, 300) });
+      console.warn(`[gbp] ${section} fetch failed for ${fullLocationName}: ${message.substring(0, 300)}`);
+      return value;
+    };
+
     const [location, reviews, insights, posts, photos, qa] = await Promise.all([
       // Location details
       gbpFetch(
         `${BUSINESS_INFO}/locations/${cleanLocId}?readMask=${encodeURIComponent('name,title,phoneNumbers,categories,storefrontAddress,websiteUri,regularHours,businessStatus,profile,metadata')}`,
         fresh
-      ).catch(() => null),
+      ).catch(fallback('location', null)),
 
       // Reviews (legacy v4)
       gbpFetch(
         `${LEGACY}/${cleanAccId}/locations/${cleanLocId}/reviews?pageSize=50`,
         fresh
-      ).catch(() => ({ reviews: [], averageRating: 0, totalReviewCount: 0 })),
+      ).catch(fallback('reviews', { reviews: [], averageRating: 0, totalReviewCount: 0 })),
 
       // Insights (legacy v4 reportInsights — POST)
       (async () => {
@@ -187,8 +198,8 @@ const connector = {
             { label: 'GBP insights' }
           );
           return res.json() as Promise<Record<string, unknown>>;
-        } catch {
-          return { locationMetrics: [] };
+        } catch (err) {
+          return fallback('insights', { locationMetrics: [] })(err);
         }
       })(),
 
@@ -196,19 +207,19 @@ const connector = {
       gbpFetch(
         `${LEGACY}/${cleanAccId}/locations/${cleanLocId}/localPosts?pageSize=20`,
         fresh
-      ).catch(() => ({ localPosts: [] })),
+      ).catch(fallback('posts', { localPosts: [] })),
 
       // Photos / media
       gbpFetch(
         `${LEGACY}/${cleanAccId}/locations/${cleanLocId}/media?pageSize=50`,
         fresh
-      ).catch(() => ({ mediaItems: [] })),
+      ).catch(fallback('photos', { mediaItems: [] })),
 
       // Q&A
       gbpFetch(
         `${LEGACY}/locations/${cleanLocId}/questions?pageSize=20&answersPerQuestion=5`,
         fresh
-      ).catch(() => ({ questions: [] })),
+      ).catch(fallback('qa', { questions: [] })),
     ]);
 
     const reviewsData = reviews as Record<string, unknown>;
@@ -224,6 +235,7 @@ const connector = {
       posts: postsData?.localPosts ?? [],
       photos: photosData?.mediaItems ?? [],
       qa: qaData?.questions ?? [],
+      partial_failures: partialFailures,
       fetchedAt: new Date().toISOString(),
     };
   },

--- a/server/connectors/google-ads/index.ts
+++ b/server/connectors/google-ads/index.ts
@@ -136,6 +136,19 @@ const connector = {
     const fresh = await ensureFreshToken(credentials);
     const managerAccountId = (params?.managerAccountId as string | undefined) || credentials?.managerAccountId;
 
+    // Previous comparison window: the 30 days immediately before the
+    // LAST_30_DAYS window used for the current totals.
+    const isoDay = (daysAgo: number) =>
+      new Date(Date.now() - daysAgo * 86400000).toISOString().slice(0, 10);
+    const prevStart = isoDay(60);
+    const prevEnd = isoDay(31);
+
+    const logSwallow = (label: string) => (err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(`[google-ads] ${label} query failed for customer ${customerId}: ${message.substring(0, 300)}`);
+      return { results: [] };
+    };
+
     // Run all GAQL queries in parallel
     const [accountTotals, accountTotalsPrev, campaigns, keywords] = await Promise.all([
       gaqlQuery(
@@ -146,16 +159,16 @@ const connector = {
          FROM customer
          WHERE segments.date DURING LAST_30_DAYS`,
         fresh, customerId, managerAccountId
-      ).catch(() => ({ results: [] })),
+      ).catch(logSwallow('account totals')),
       gaqlQuery(
         `SELECT
            metrics.clicks, metrics.impressions, metrics.cost_micros,
            metrics.conversions, metrics.conversions_value,
            metrics.average_cpc, metrics.ctr
          FROM customer
-         WHERE segments.date BETWEEN '2025-03-01' AND '2025-03-31'`,
+         WHERE segments.date BETWEEN '${prevStart}' AND '${prevEnd}'`,
         fresh, customerId, managerAccountId
-      ).catch(() => ({ results: [] })),
+      ).catch(logSwallow('previous-period totals')),
       gaqlQuery(
         `SELECT
            campaign.id, campaign.name, campaign.status,
@@ -170,7 +183,7 @@ const connector = {
          ORDER BY metrics.cost_micros DESC
          LIMIT 20`,
         fresh, customerId, managerAccountId
-      ).catch(() => ({ results: [] })),
+      ).catch(logSwallow('campaigns')),
       gaqlQuery(
         `SELECT
            ad_group_criterion.keyword.text,
@@ -182,7 +195,7 @@ const connector = {
          ORDER BY metrics.cost_micros DESC
          LIMIT 50`,
         fresh, customerId, managerAccountId
-      ).catch(() => ({ results: [] })),
+      ).catch(logSwallow('keywords')),
     ]);
 
     function aggregateMetrics(results: Record<string, unknown>): Record<string, number> {

--- a/server/connectors/meta-ads/index.ts
+++ b/server/connectors/meta-ads/index.ts
@@ -73,6 +73,27 @@ async function withRetry(
 }
 
 /**
+ * Fetch every page of a Graph API list endpoint by following `paging.next`
+ * cursors. Returns the merged rows in the same `{ data: [...] }` shape the
+ * single-page calls produced, so existing consumers keep working. Capped at
+ * `maxPages` to bound runtime on very large ad accounts.
+ */
+async function fetchAllPages(firstUrl: string, maxPages = 10): Promise<{ data: unknown[] }> {
+  const rows: unknown[] = [];
+  let url: string | undefined = firstUrl;
+  for (let page = 0; page < maxPages && url; page++) {
+    const res = await withRetry(() => fetch(url!) as Promise<FetchLike>);
+    const json = await res.json() as { data?: unknown[]; paging?: { next?: string } };
+    rows.push(...(json.data ?? []));
+    url = json.paging?.next;
+  }
+  if (url) {
+    console.warn(`[meta-ads] Pagination capped at ${maxPages} pages — some rows were not fetched.`);
+  }
+  return { data: rows };
+}
+
+/**
  * Get number (safe parse, falls back to 0 for null/undefined/non-numeric).
  */
 function num(v: unknown): number {
@@ -171,8 +192,9 @@ async function fetchInsights(credentials: Creds, config: Record<string, unknown>
   })) as Promise<FetchLike>);
   const account = await accountRes.json();
 
-  // 2) Campaign-level insights (last 30 days)
-  const campaignsRes = await withRetry(() => fetch(`${GRAPH_BASE}/${accountId}/insights?` + new URLSearchParams({
+  // 2) Campaign-level insights (last 30 days) — paginated so accounts with
+  // many campaigns aren't silently truncated.
+  const campaigns = await fetchAllPages(`${GRAPH_BASE}/${accountId}/insights?` + new URLSearchParams({
     fields: [
       'campaign_name', 'campaign_id', 'objective',
       'impressions', 'reach', 'clicks', 'spend',
@@ -181,10 +203,9 @@ async function fetchInsights(credentials: Creds, config: Record<string, unknown>
     ].join(','),
     level: 'campaign',
     date_preset: 'last_30d',
-    limit: '20',
+    limit: '50',
     access_token: creds.access_token!,
-  })) as Promise<FetchLike>);
-  const campaigns = await campaignsRes.json();
+  }));
 
   // 3) Previous period (31-60 days ago) for comparison
   const prevRes = await withRetry(() => fetch(`${GRAPH_BASE}/${accountId}/insights?` + new URLSearchParams({
@@ -205,13 +226,12 @@ async function fetchCampaigns(credentials: Creds, config: Record<string, unknown
   const accountId = (config.adAccountId as string | undefined) || credentials.ad_account_id;
   if (!accountId) throw new Error('Meta Ads: adAccountId is required.');
 
-  const res = await withRetry(() => fetch(`${GRAPH_BASE}/${accountId}/campaigns?` + new URLSearchParams({
+  return fetchAllPages(`${GRAPH_BASE}/${accountId}/campaigns?` + new URLSearchParams({
     fields: 'id,name,status,objective,daily_budget,lifetime_budget,start_time,stop_time',
     effective_status: JSON.stringify(['ACTIVE', 'PAUSED']),
     limit: '50',
     access_token: creds.access_token!,
-  })) as Promise<FetchLike>);
-  return res.json();
+  }));
 }
 
 async function fetchAdSets(credentials: Creds, config: Record<string, unknown>): Promise<unknown> {
@@ -219,13 +239,12 @@ async function fetchAdSets(credentials: Creds, config: Record<string, unknown>):
   const accountId = (config.adAccountId as string | undefined) || credentials.ad_account_id;
   if (!accountId) throw new Error('Meta Ads: adAccountId is required.');
 
-  const res = await withRetry(() => fetch(`${GRAPH_BASE}/${accountId}/adsets?` + new URLSearchParams({
+  return fetchAllPages(`${GRAPH_BASE}/${accountId}/adsets?` + new URLSearchParams({
     fields: 'id,name,campaign_id,status,daily_budget,targeting,billing_event,optimization_goal',
     effective_status: JSON.stringify(['ACTIVE', 'PAUSED']),
     limit: '50',
     access_token: creds.access_token!,
-  })) as Promise<FetchLike>);
-  return res.json();
+  }));
 }
 
 // ─── Connector interface ─────────────────────────────────────────────────────

--- a/server/connectors/shopify/index.ts
+++ b/server/connectors/shopify/index.ts
@@ -29,6 +29,29 @@ function shopifyFetch(
   return fetch(url, options);
 }
 
+/**
+ * shopifyFetch with 429 backoff. Shopify's REST API allows ~2 req/s; large
+ * stores paginating at 250 items/page will hit the limit mid-loop, which
+ * previously failed the whole sync. Honours Retry-After when present.
+ */
+async function shopifyFetchRetry(
+  credentials: Creds,
+  path: string,
+  label: string,
+): Promise<Awaited<ReturnType<typeof shopifyFetch>>> {
+  const maxRetries = 4;
+  for (let attempt = 0; ; attempt++) {
+    const res = await shopifyFetch(credentials, path);
+    if (res.status !== 429 || attempt >= maxRetries) return res;
+    const retryAfterSec = Number(res.headers.get('retry-after'));
+    const delayMs = Number.isFinite(retryAfterSec) && retryAfterSec > 0
+      ? Math.min(retryAfterSec, 60) * 1000
+      : 1000 * Math.pow(2, attempt);
+    console.warn(`[shopify] Rate limited on ${label}. Retry ${attempt + 1}/${maxRetries} in ${delayMs}ms`);
+    await new Promise(r => setTimeout(r, delayMs));
+  }
+}
+
 function dateString(daysAgo: number): string {
   const d = new Date();
   d.setDate(d.getDate() - daysAgo);
@@ -93,7 +116,7 @@ async function fetchOrders(credentials: Creds, daysAgo = 120): Promise<ShopifyOr
   let url: string | null = `/orders.json?status=any&processed_at_min=${encodeURIComponent(since)}&limit=250&fields=id,name,created_at,processed_at,total_price,subtotal_price,total_tax,financial_status,fulfillment_status,line_items,customer,source_name,cancel_reason,email`;
 
   while (url) {
-    const res = await shopifyFetch(credentials, url);
+    const res = await shopifyFetchRetry(credentials, url, 'orders');
     if (!res.ok) {
       const err = await res.text();
       throw new Error(`Shopify orders error ${res.status}: ${err.substring(0, 300)}`);
@@ -118,8 +141,13 @@ async function fetchProducts(credentials: Creds): Promise<ShopifyProduct[]> {
   let url: string | null = `/products.json?status=active&limit=250&fields=id,title,handle,status,variants,images,product_type,tags,created_at,updated_at`;
 
   while (url) {
-    const res = await shopifyFetch(credentials, url);
-    if (!res.ok) break;
+    const res = await shopifyFetchRetry(credentials, url, 'products');
+    if (!res.ok) {
+      // A mid-pagination failure must not silently truncate the catalogue —
+      // downstream product/inventory metrics would be wrong.
+      const err = await res.text();
+      throw new Error(`Shopify products error ${res.status}: ${err.substring(0, 300)}`);
+    }
     const data = await res.json() as { products?: ShopifyProduct[] };
     products.push(...(data.products ?? []));
 
@@ -135,8 +163,11 @@ async function fetchProducts(credentials: Creds): Promise<ShopifyProduct[]> {
  * Fetch customers (most recent 250 for overview).
  */
 async function fetchCustomers(credentials: Creds): Promise<ShopifyCustomer[]> {
-  const res = await shopifyFetch(credentials, `/customers.json?limit=250&fields=id,email,first_name,last_name,orders_count,total_spent,created_at,tags`);
-  if (!res.ok) return [];
+  const res = await shopifyFetchRetry(credentials, `/customers.json?limit=250&fields=id,email,first_name,last_name,orders_count,total_spent,created_at,tags`, 'customers');
+  if (!res.ok) {
+    console.warn(`[shopify] customers fetch failed (${res.status}) — customer metrics will be empty this sync.`);
+    return [];
+  }
   const data = await res.json() as { customers?: ShopifyCustomer[] };
   return data.customers ?? [];
 }
@@ -460,7 +491,10 @@ const connector = {
 
   async fetchCollections(credentials: Creds): Promise<unknown[]> {
     const res = await shopifyFetch(credentials, '/custom_collections.json?limit=50');
-    if (!res.ok) return [];
+    if (!res.ok) {
+      console.warn(`[shopify] collections fetch failed (${res.status}) — returning empty list.`);
+      return [];
+    }
     const data = await res.json() as { custom_collections?: unknown[] };
     return data.custom_collections ?? [];
   },

--- a/server/connectors/stripe/index.ts
+++ b/server/connectors/stripe/index.ts
@@ -26,8 +26,9 @@ interface StripeSubscription {
 
 function getClient(credentials: Creds): Stripe {
   if (!credentials?.apiKey) throw new Error('Stripe API key is required.');
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return new Stripe(credentials.apiKey, { apiVersion: '2024-06-20' as any });
+  // No apiVersion override: the SDK pins the API version it was built and
+  // typed against, which is safer than forcing an older version with a cast.
+  return new Stripe(credentials.apiKey);
 }
 
 function calculateMRR(subscriptions: StripeSubscription[]): number {

--- a/server/connectors/todoist/index.ts
+++ b/server/connectors/todoist/index.ts
@@ -167,7 +167,7 @@ const connector = {
     return `${AUTH_BASE}?${params.toString()}`;
   },
 
-  async exchangeCode(_code?: string): Promise<never> {
+  async exchangeCode(code: string): Promise<{ accessToken: string; refreshToken?: string; expiresAt?: string; scope?: string }> {
     const clientId = process.env.TODOIST_CLIENT_ID;
     const clientSecret = process.env.TODOIST_CLIENT_SECRET;
     const redirectUri = process.env.TODOIST_REDIRECT_URI || 'http://localhost:4000/api/oauth/todoist/callback';
@@ -180,22 +180,24 @@ const connector = {
       body: new URLSearchParams({
         client_id: clientId,
         client_secret: clientSecret,
-        code: _code ?? '',
+        code,
         redirect_uri: redirectUri,
       }),
     });
     const tokens = await res.json() as TodoistTokenResponse;
-    return {
-      accessToken: tokens.access_token,
-      refreshToken: null, // Todoist tokens don't expire
-      expiresAt: null,
-      scope: tokens.token_type ? SCOPES : null,
-    } as never;
+    if (!tokens.access_token) {
+      throw new Error('Todoist code exchange returned no access_token.');
+    }
+    // Todoist tokens don't expire — no refreshToken/expiresAt.
+    return { accessToken: tokens.access_token, scope: SCOPES };
   },
 
-  async refreshToken(_credentials?: Creds): Promise<never> {
-    // Todoist tokens never expire — return as-is.
-    return _credentials as never;
+  async refreshToken(credentials: Creds): Promise<{ accessToken: string; expiresAt?: string }> {
+    // Todoist tokens never expire — return the existing token unchanged.
+    if (!credentials?.accessToken) {
+      throw new Error('Todoist access token missing — re-authorise the connector.');
+    }
+    return { accessToken: credentials.accessToken };
   },
 };
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -122,7 +122,11 @@ app.use(express.urlencoded({ extended: true }));
 // Sessions
 const sessionSecret = process.env.SESSION_SECRET;
 if (!sessionSecret) {
-  console.error('[startup] CRITICAL: SESSION_SECRET environment variable is not set!');
+  if (process.env.NODE_ENV === 'production') {
+    console.error('[startup] FATAL: SESSION_SECRET must be set in production. Refusing to start with a guessable session secret.');
+    process.exit(1);
+  }
+  console.error('[startup] CRITICAL: SESSION_SECRET environment variable is not set! Using an insecure dev-only fallback.');
 }
 
 app.use(session({
@@ -487,6 +491,9 @@ const mountRoutes = async () => {
 // ─── Startup ─────────────────────────────────────────────────────────────────
 
 async function start(): Promise<void> {
+  // Declared before the shutdown handlers below so a signal arriving during
+  // startup doesn't hit a temporal-dead-zone ReferenceError.
+  let server: ReturnType<typeof app.listen> | undefined;
   try {
     // Ensure data directory exists
     mkdirSync(resolve(__dirname, '../data'), { recursive: true });
@@ -570,7 +577,7 @@ async function start(): Promise<void> {
     }
 
     // Start server
-    const server = app.listen(PORT, () => {
+    server = app.listen(PORT, () => {
       console.log(`[startup] Blueprint server running on http://localhost:${PORT}`);
       console.log(`[startup] Environment: ${process.env.NODE_ENV || 'development'}`);
       console.log(`[startup] API health: http://localhost:${PORT}/api/health`);

--- a/server/jobs/scheduler.ts
+++ b/server/jobs/scheduler.ts
@@ -380,6 +380,42 @@ export function startScheduler(): void {
     }
   });
 
+  // Every day at 04:30: prune old metric snapshots. The metrics table is an
+  // append-only time series (every sync writes named metrics + a full raw
+  // blob) and grows without bound otherwise. Named metrics are kept longer
+  // than the heavy `*_sync` raw blobs. Retention is configurable via the
+  // settings keys metrics_retention_days / sync_blob_retention_days.
+  cron.schedule('30 4 * * *', () => {
+    try {
+      const getSetting = (key: string, fallback: number): number => {
+        try {
+          const row = db.prepare('SELECT value FROM settings WHERE key = ?').get(key) as { value: string } | undefined;
+          const n = row ? Number(JSON.parse(row.value)) : NaN;
+          return Number.isFinite(n) && n > 0 ? n : fallback;
+        } catch { return fallback; }
+      };
+      const metricDays = getSetting('metrics_retention_days', 365);
+      const blobDays = getSetting('sync_blob_retention_days', 60);
+
+      const blobs = db.prepare(`
+        DELETE FROM metrics
+        WHERE metric_name LIKE '%\\_sync' ESCAPE '\\'
+          AND recorded_at < datetime('now', '-' || ? || ' days')
+      `).run(blobDays);
+      const named = db.prepare(`
+        DELETE FROM metrics
+        WHERE metric_name NOT LIKE '%\\_sync' ESCAPE '\\'
+          AND recorded_at < datetime('now', '-' || ? || ' days')
+      `).run(metricDays);
+
+      if ((blobs.changes ?? 0) > 0 || (named.changes ?? 0) > 0) {
+        console.log(`[scheduler] Metrics retention: pruned ${blobs.changes} sync blobs (>${blobDays}d) and ${named.changes} named metrics (>${metricDays}d).`);
+      }
+    } catch (err) {
+      console.error('[scheduler] Metrics retention pruning failed:', err);
+    }
+  });
+
   // Every 5 minutes: process timed approvals
   cron.schedule('*/5 * * * *', async () => {
     try {

--- a/server/lib/rate-limiter.test.ts
+++ b/server/lib/rate-limiter.test.ts
@@ -1,0 +1,83 @@
+import { describe, test, expect } from 'bun:test';
+import { withRetry } from './rate-limiter.ts';
+
+function httpError(status: number, retryAfterMs?: number): Error {
+  const err = new Error(`HTTP ${status}`) as Error & { status: number; retryAfterMs?: number };
+  err.status = status;
+  err.retryAfterMs = retryAfterMs;
+  return err;
+}
+
+describe('withRetry', () => {
+  test('returns the result on first success', async () => {
+    let calls = 0;
+    const result = await withRetry(async () => { calls++; return 'ok'; });
+    expect(result).toBe('ok');
+    expect(calls).toBe(1);
+  });
+
+  test('retries 429 and eventually succeeds', async () => {
+    let calls = 0;
+    const result = await withRetry(async () => {
+      calls++;
+      if (calls < 3) throw httpError(429);
+      return 'ok';
+    }, { baseDelayMs: 1 });
+    expect(result).toBe('ok');
+    expect(calls).toBe(3);
+  });
+
+  test('retries 502/503/504 gateway errors', async () => {
+    for (const status of [502, 503, 504]) {
+      let calls = 0;
+      const result = await withRetry(async () => {
+        calls++;
+        if (calls === 1) throw httpError(status);
+        return 'ok';
+      }, { baseDelayMs: 1 });
+      expect(result).toBe('ok');
+      expect(calls).toBe(2);
+    }
+  });
+
+  test('does not retry non-transient errors (400, 401, 404, 500)', async () => {
+    for (const status of [400, 401, 404, 500]) {
+      let calls = 0;
+      await expect(withRetry(async () => {
+        calls++;
+        throw httpError(status);
+      }, { baseDelayMs: 1 })).rejects.toThrow(`HTTP ${status}`);
+      expect(calls).toBe(1);
+    }
+  });
+
+  test('does not retry plain errors without a status', async () => {
+    let calls = 0;
+    await expect(withRetry(async () => {
+      calls++;
+      throw new Error('boom');
+    }, { baseDelayMs: 1 })).rejects.toThrow('boom');
+    expect(calls).toBe(1);
+  });
+
+  test('gives up after maxRetries and rethrows the last error', async () => {
+    let calls = 0;
+    await expect(withRetry(async () => {
+      calls++;
+      throw httpError(429);
+    }, { maxRetries: 2, baseDelayMs: 1 })).rejects.toThrow('HTTP 429');
+    expect(calls).toBe(3); // initial attempt + 2 retries
+  });
+
+  test('honours retryAfterMs hint from the error', async () => {
+    let calls = 0;
+    const started = Date.now();
+    const result = await withRetry(async () => {
+      calls++;
+      if (calls === 1) throw httpError(429, 30);
+      return 'ok';
+    }, { baseDelayMs: 5000 }); // backoff would be 5s — Retry-After should win
+    expect(result).toBe('ok');
+    expect(Date.now() - started).toBeLessThan(2000);
+  });
+});

--- a/server/lib/rate-limiter.ts
+++ b/server/lib/rate-limiter.ts
@@ -12,7 +12,11 @@ interface HttpError extends Error {
   status?: number;
   statusCode?: number;
   statusText?: string;
+  retryAfterMs?: number;
 }
+
+/** Transient statuses worth retrying: rate limits and gateway hiccups. */
+const RETRYABLE_STATUSES = new Set([429, 502, 503, 504]);
 
 export async function withRetry<T>(fn: () => Promise<T>, options: RetryOptions = {}): Promise<T> {
   const { maxRetries = 3, baseDelayMs = 1000, label = 'API call' } = options;
@@ -23,13 +27,18 @@ export async function withRetry<T>(fn: () => Promise<T>, options: RetryOptions =
     } catch (err) {
       const e = err as HttpError;
       const status = e?.status ?? e?.statusCode ?? null;
-      const isRateLimit = status === 429 || status === 503;
+      const isRetryable = status !== null && RETRYABLE_STATUSES.has(status);
       const isLastAttempt = attempt === maxRetries;
 
-      if (isLastAttempt || !isRateLimit) throw err;
+      if (isLastAttempt || !isRetryable) throw err;
 
-      const delay = baseDelayMs * Math.pow(2, attempt);
-      console.warn(`[rate-limiter] ${label} rate limited (status ${status}). Retry ${attempt + 1}/${maxRetries} in ${delay}ms`);
+      // Honour the server's Retry-After hint when present (capped at 60s),
+      // otherwise exponential backoff.
+      const backoff = baseDelayMs * Math.pow(2, attempt);
+      const delay = e.retryAfterMs !== undefined && Number.isFinite(e.retryAfterMs)
+        ? Math.min(Math.max(e.retryAfterMs, 0), 60_000)
+        : backoff;
+      console.warn(`[rate-limiter] ${label} transient failure (status ${status}). Retry ${attempt + 1}/${maxRetries} in ${delay}ms`);
       await new Promise(r => setTimeout(r, delay));
     }
   }
@@ -42,13 +51,25 @@ export async function withRetry<T>(fn: () => Promise<T>, options: RetryOptions =
 class CheckedFetchError extends Error {
   readonly status: number;
   readonly statusText: string;
+  readonly retryAfterMs?: number;
 
-  constructor(message: string, status: number, statusText: string) {
+  constructor(message: string, status: number, statusText: string, retryAfterMs?: number) {
     super(message);
     this.name = 'CheckedFetchError';
     this.status = status;
     this.statusText = statusText;
+    this.retryAfterMs = retryAfterMs;
   }
+}
+
+/** Parse a Retry-After header (delta-seconds or HTTP date) into milliseconds. */
+function parseRetryAfter(header: string | null): number | undefined {
+  if (!header) return undefined;
+  const seconds = Number(header);
+  if (Number.isFinite(seconds)) return seconds * 1000;
+  const date = Date.parse(header);
+  if (!Number.isNaN(date)) return Math.max(0, date - Date.now());
+  return undefined;
 }
 
 export async function checkedFetch(url: string, init: RequestInit = {}): Promise<Response> {
@@ -60,6 +81,7 @@ export async function checkedFetch(url: string, init: RequestInit = {}): Promise
       `HTTP ${res.status} ${res.statusText} for ${url}: ${body}`,
       res.status,
       res.statusText,
+      parseRetryAfter(res.headers.get('retry-after')),
     );
   }
   return res;

--- a/server/notifications/dispatcher.ts
+++ b/server/notifications/dispatcher.ts
@@ -67,9 +67,18 @@ export async function dispatch(notification: Notification): Promise<DispatchResu
       }
 
       case 'email': {
-        // Email adapter — not yet implemented
-        console.warn('[dispatcher] Email channel not yet implemented.');
-        result = { ok: false, error: 'Email channel not implemented.' };
+        const { sendEmail, getEmailRecipient } = await import('./email.js');
+        const to = getEmailRecipient();
+        if (!to) {
+          result = { ok: false, error: 'Email recipient not configured (Settings → Notifications).' };
+          break;
+        }
+        const sent = await sendEmail({
+          to,
+          subject: `[${notification.severity}] ${notification.title}`,
+          text: notification.body ?? notification.title,
+        });
+        result = { ok: sent.ok };
         break;
       }
 

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,7 @@
     "@anthropic-ai/sdk": "^0.27.0",
     "@isomorphic-git/lightning-fs": "^4.6.0",
     "basic-ftp": "^5.2.2",
-    "bcryptjs": "^2.4.3",
+    "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.18.3",
@@ -30,7 +30,6 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "@types/bcryptjs": "^3.0.0",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/express-session": "^1.18.2",

--- a/server/roi/value-estimator.ts
+++ b/server/roi/value-estimator.ts
@@ -143,15 +143,34 @@ function getAOV(businessId: string): number | null {
  * Business's baseline conversion rate as a decimal (0.025 = 2.5%).
  * Tries shopify first, then ga4.
  */
+/**
+ * Normalise a stored conversion-rate baseline to a decimal.
+ * Baselines have no unit metadata, so this is a heuristic: e-commerce
+ * conversion rates virtually never exceed 20% as a decimal, so anything
+ * above 0.2 is assumed to be a percentage (e.g. 2.5 → 0.025). Values that
+ * remain implausible after conversion are rejected rather than fed into
+ * revenue estimates.
+ */
+function normaliseConversionRate(raw: number): number | null {
+  if (!Number.isFinite(raw) || raw <= 0) return null;
+  const decimal = raw > 0.2 ? raw / 100 : raw;
+  if (decimal > 0.5) {
+    console.warn(`[value-estimator] Implausible conversion rate baseline ${raw} — ignoring.`);
+    return null;
+  }
+  return decimal;
+}
+
 function getConversionRate(businessId: string): number | null {
   const shop = getBaseline(businessId, 'shopify.conversion_rate');
   if (shop && Number.isFinite(shop.baseline_value)) {
-    // Store as decimal — if baseline looks like a % (>1), divide by 100.
-    return (shop.baseline_value as number) > 1 ? (shop.baseline_value as number) / 100 : (shop.baseline_value as number);
+    const rate = normaliseConversionRate(shop.baseline_value as number);
+    if (rate !== null) return rate;
   }
   const ga4 = getBaseline(businessId, 'ga4.conversion_rate');
   if (ga4 && Number.isFinite(ga4.baseline_value)) {
-    return (ga4.baseline_value as number) > 1 ? (ga4.baseline_value as number) / 100 : (ga4.baseline_value as number);
+    const rate = normaliseConversionRate(ga4.baseline_value as number);
+    if (rate !== null) return rate;
   }
   return null;
 }

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -1,6 +1,5 @@
 import { Router } from 'express';
 import type { Request, Response } from 'express';
-// @ts-ignore — bcryptjs types are present but excluded by tsconfig "types":["bun-types"]
 import bcrypt from 'bcryptjs';
 
 import { isAuthenticated } from '../middleware/auth.js';
@@ -49,7 +48,7 @@ async function getPasswordHash(): Promise<string> {
   if (!rawPassword) {
     throw new Error('ADMIN_PASSWORD environment variable is not set.');
   }
-  const hash = await (bcrypt as any).hash(rawPassword, 12) as string;
+  const hash = await bcrypt.hash(rawPassword, 12);
   passwordHash = hash;
   return hash;
 }

--- a/server/signals/rules.test.ts
+++ b/server/signals/rules.test.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect } from 'bun:test';
+import { rules } from './rules.ts';
+import type { SignalRule } from './rules.ts';
+
+function getRule(id: string): SignalRule {
+  const rule = rules.find(r => r.id === id);
+  if (!rule) throw new Error(`Rule '${id}' not found`);
+  return rule;
+}
+
+describe('signal rules — defensive behaviour', () => {
+  test('no rule raises a false alarm when there is no data yet', () => {
+    // The signal engine catches rules that throw on missing data, so a throw
+    // is tolerated — but a rule that *triggers* on empty input would create
+    // false alarms (e.g. "balance low: £0.00") the moment a connector syncs
+    // with no data. That must never happen.
+    for (const rule of rules) {
+      for (const [current, previous] of [
+        [undefined, undefined],
+        [null, null],
+        [{}, {}],
+      ] as const) {
+        let result;
+        try {
+          result = rule.evaluate(current, previous);
+        } catch {
+          continue; // engine skips throwing rules
+        }
+        if (result.triggered) {
+          throw new Error(`Rule '${rule.id}' triggered on empty input ${JSON.stringify(current)}: "${result.title}"`);
+        }
+      }
+    }
+  });
+
+  test('traffic_drop_7day does not divide by zero when previous sessions are 0', () => {
+    const rule = getRule('traffic_drop_7day');
+    const result = rule.evaluate({ sessions: 100 }, { sessions: 0 });
+    expect(result.triggered).toBe(false);
+    expect(Number.isNaN(result.confidence)).toBe(false);
+  });
+
+  test('traffic_drop_7day triggers on a 20%+ drop with sane confidence', () => {
+    const rule = getRule('traffic_drop_7day');
+    const result = rule.evaluate({ sessions: 50 }, { sessions: 100 });
+    expect(result.triggered).toBe(true);
+    expect(result.confidence).toBeGreaterThan(0);
+    expect(result.confidence).toBeLessThanOrEqual(0.95);
+    expect(result.data.dropPct).toBe(50);
+  });
+
+  test('traffic_drop_7day does not trigger on a small drop', () => {
+    const rule = getRule('traffic_drop_7day');
+    const result = rule.evaluate({ sessions: 95 }, { sessions: 100 });
+    expect(result.triggered).toBe(false);
+  });
+
+  test('ranking_drop_keyword handles non-array input without throwing', () => {
+    const rule = getRule('ranking_drop_keyword');
+    expect(rule.evaluate({ not: 'an array' }, 42).triggered).toBe(false);
+  });
+
+  test('ranking_drop_keyword triggers when a keyword drops 5+ positions', () => {
+    const rule = getRule('ranking_drop_keyword');
+    const previous = [{ query: 'best widgets', position: 3, clicks: 100, impressions: 1000 }];
+    const current = [{ query: 'best widgets', position: 9, clicks: 20, impressions: 900 }];
+    const result = rule.evaluate(current, previous);
+    expect(result.triggered).toBe(true);
+  });
+
+  test('every rule result has the required shape', () => {
+    for (const rule of rules) {
+      let result;
+      try {
+        result = rule.evaluate({}, {});
+      } catch {
+        continue; // engine skips throwing rules
+      }
+      expect(typeof result.triggered).toBe('boolean');
+      expect(typeof result.confidence).toBe('number');
+      expect(Number.isNaN(result.confidence)).toBe(false);
+      expect(typeof result.title).toBe('string');
+      expect(typeof result.description).toBe('string');
+    }
+  });
+});

--- a/server/signals/rules.test.ts
+++ b/server/signals/rules.test.ts
@@ -9,11 +9,12 @@ function getRule(id: string): SignalRule {
 }
 
 describe('signal rules — defensive behaviour', () => {
-  test('no rule raises a false alarm when there is no data yet', () => {
-    // The signal engine catches rules that throw on missing data, so a throw
-    // is tolerated — but a rule that *triggers* on empty input would create
-    // false alarms (e.g. "balance low: £0.00") the moment a connector syncs
-    // with no data. That must never happen.
+  test('no rule throws or raises a false alarm when there is no data yet', () => {
+    // The signal engine normalises null → undefined before calling evaluate()
+    // (so rules' `= {}` parameter defaults apply). Under that convention every
+    // rule must (a) not throw and (b) not trigger on empty input — a rule
+    // that triggers on missing data creates false alarms (e.g. "balance low:
+    // £0.00") the moment a connector syncs with no data.
     for (const rule of rules) {
       for (const [current, previous] of [
         [undefined, undefined],
@@ -22,9 +23,9 @@ describe('signal rules — defensive behaviour', () => {
       ] as const) {
         let result;
         try {
-          result = rule.evaluate(current, previous);
-        } catch {
-          continue; // engine skips throwing rules
+          result = rule.evaluate(current ?? undefined, previous ?? undefined);
+        } catch (err) {
+          throw new Error(`Rule '${rule.id}' threw on empty input ${JSON.stringify(current)}: ${(err as Error).message}`);
         }
         if (result.triggered) {
           throw new Error(`Rule '${rule.id}' triggered on empty input ${JSON.stringify(current)}: "${result.title}"`);

--- a/server/signals/rules.ts
+++ b/server/signals/rules.ts
@@ -1,6 +1,3 @@
-// @ts-nocheck — rules are data-driven config; each evaluate() body
-// accesses connector-specific shapes that are too varied to type explicitly.
-// The exported interfaces (RuleResult, SignalRule) remain usable by callers.
 /* eslint-disable */
 /**
  * Signal rules.
@@ -199,7 +196,7 @@ export const rules: SignalRule[] = [
     severity: 'alert',
     name: 'LCP Failing Core Web Vitals',
 
-    evaluate(current, _previous) {
+    evaluate(current: any, _previous?: any): RuleResult {
       const lcp = current?.cwv?.lcp ?? null;
       const strategy = current?.strategy ?? 'mobile';
 
@@ -277,7 +274,7 @@ export const rules: SignalRule[] = [
     severity: 'info',
     name: 'Low CTR on High-Impression Keywords',
 
-    evaluate(current, _previous) {
+    evaluate(current: any, _previous?: any): RuleResult {
       if (!Array.isArray(current)) {
         return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
       }
@@ -318,7 +315,7 @@ export const rules: SignalRule[] = [
     severity: 'alert',
     name: 'CLS Failing Core Web Vitals',
 
-    evaluate(current, _previous) {
+    evaluate(current: any, _previous?: any): RuleResult {
       const cls = current?.cwv?.cls ?? null;
       if (cls === null) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
       const triggered = cls > 0.1;
@@ -340,7 +337,7 @@ export const rules: SignalRule[] = [
     severity: 'warning',
     name: 'FID/TBT Failing Core Web Vitals',
 
-    evaluate(current, _previous) {
+    evaluate(current: any, _previous?: any): RuleResult {
       const fid = current?.cwv?.fid ?? current?.cwv?.tbt ?? null;
       if (fid === null) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
       const triggered = fid > 100;
@@ -362,7 +359,7 @@ export const rules: SignalRule[] = [
     severity: 'alert',
     name: 'Mobile Performance Score Below 50',
 
-    evaluate(current, _previous) {
+    evaluate(current: any, _previous?: any): RuleResult {
       const score = current?.scores?.performance ?? null;
       if (score === null) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
       const triggered = score < 50;
@@ -384,11 +381,11 @@ export const rules: SignalRule[] = [
     severity: 'info',
     name: 'PageSpeed Opportunities Detected',
 
-    evaluate(current, _previous) {
+    evaluate(current: any, _previous?: any): RuleResult {
       const opportunities = current?.opportunities ?? [];
-      const highValue = opportunities.filter(o => (o.savingsMs ?? 0) > 500);
+      const highValue = opportunities.filter((o: any) => (o.savingsMs ?? 0) > 500);
       const triggered = highValue.length > 0;
-      const totalSavings = highValue.reduce((sum, o) => sum + (o.savingsMs ?? 0), 0);
+      const totalSavings = highValue.reduce((sum: any, o: any) => sum + (o.savingsMs ?? 0), 0);
       return {
         triggered,
         confidence: triggered ? Math.min(0.9, 0.5 + highValue.length * 0.1) : 0,
@@ -457,9 +454,9 @@ export const rules: SignalRule[] = [
     name: 'Organic Traffic Drop',
 
     evaluate(current: any, previous: any): RuleResult {
-      const getOrganic = (data) => {
+      const getOrganic = (data: any) => {
         if (!Array.isArray(data?.sources)) return null;
-        const org = data.sources.find(s =>
+        const org = data.sources.find((s: any) =>
           s.channel?.toLowerCase().includes('organic') || s.channel?.toLowerCase().includes('search')
         );
         return org?.sessions ?? null;
@@ -492,12 +489,12 @@ export const rules: SignalRule[] = [
       if (!current?.current || !previous?.current) {
         return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
       }
-      const prevMap = new Map((previous.current ?? []).map(r => [r.query, r]));
+      const prevMap = new Map<string, any>((previous.current ?? []).map((r: any) => [r.query, r]));
       const top10 = [...prevMap.values()]
-        .sort((a, b) => b.impressions - a.impressions)
+        .sort((a: any, b: any) => b.impressions - a.impressions)
         .slice(0, 10)
-        .map(r => r.query);
-      const currMap = new Map((current.current ?? []).map(r => [r.query, r]));
+        .map((r: any) => r.query);
+      const currMap = new Map<string, any>((current.current ?? []).map((r: any) => [r.query, r]));
       const dropped = [];
       for (const query of top10) {
         const prev = prevMap.get(query);
@@ -640,11 +637,11 @@ export const rules: SignalRule[] = [
     severity: 'alert',
     name: 'No Shopify Orders Today',
 
-    evaluate(current, _previous) {
+    evaluate(current: any, _previous?: any): RuleResult {
       const daily = current?.current?.dailySales ?? [];
       if (daily.length === 0) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
       const today = new Date().toISOString().substring(0, 10);
-      const todayEntry = daily.find(d => d.date === today);
+      const todayEntry = daily.find((d: any) => d.date === today);
       const triggered = !todayEntry || todayEntry.amount === 0;
       return {
         triggered,
@@ -666,9 +663,9 @@ export const rules: SignalRule[] = [
     name: 'Monitor Down',
     evaluate(current: any): RuleResult {
       const monitors = current?.monitors ?? [];
-      const down = monitors.filter(m => m?.status === 9);
+      const down = monitors.filter((m: any) => m?.status === 9);
       if (down.length === 0) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
-      const names = down.map(m => m.friendly_name).filter(Boolean);
+      const names = down.map((m: any) => m.friendly_name).filter(Boolean);
       return {
         triggered: true,
         confidence: 1.0,
@@ -687,9 +684,9 @@ export const rules: SignalRule[] = [
     name: 'Monitor Seems Down',
     evaluate(current: any): RuleResult {
       const monitors = current?.monitors ?? [];
-      const seems = monitors.filter(m => m?.status === 8);
+      const seems = monitors.filter((m: any) => m?.status === 8);
       if (seems.length === 0) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
-      const names = seems.map(m => m.friendly_name).filter(Boolean);
+      const names = seems.map((m: any) => m.friendly_name).filter(Boolean);
       return {
         triggered: true,
         confidence: 0.85,
@@ -710,18 +707,18 @@ export const rules: SignalRule[] = [
       const monitors = current?.monitors ?? [];
       if (monitors.length === 0) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
       const below = monitors
-        .map(m => {
-          const ratio = parseFloat(String(m.custom_uptime_ratio ?? '').split('-').pop());
+        .map((m: any) => {
+          const ratio = parseFloat(String(m.custom_uptime_ratio ?? '').split('-').pop() ?? '');
           return isNaN(ratio) ? null : { name: m.friendly_name, ratio };
         })
-        .filter(x => x && x.ratio < 99.5);
+        .filter((x: any) => x && x.ratio < 99.5);
       if (below.length === 0) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
       return {
         triggered: true,
         confidence: 0.95,
         data: { monitors: below },
         title: `${below.length} monitor${below.length > 1 ? 's' : ''} below 99.5% uptime (30-day)`,
-        description: below.map(b => `${b.name}: ${b.ratio}%`).join(', '),
+        description: below.map((b: any) => `${b.name}: ${b.ratio}%`).join(', '),
       };
     },
   },
@@ -736,7 +733,7 @@ export const rules: SignalRule[] = [
       const currMons = current?.monitors ?? [];
       const prevMons = previous?.monitors ?? [];
       if (currMons.length === 0 || prevMons.length === 0) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
-      const prevById = new Map(prevMons.map(m => [m.id, m]));
+      const prevById = new Map<any, any>(prevMons.map((m: any) => [m.id, m]));
       const spiked = [];
       for (const m of currMons) {
         const curr = m.response_times?.[0]?.value ?? 0;
@@ -766,14 +763,14 @@ export const rules: SignalRule[] = [
     name: 'High-Priority Tasks Overdue',
     evaluate(current: any): RuleResult {
       const overdue = current?.overdue_tasks ?? [];
-      const p1 = overdue.filter(t => t.priority === 4);
+      const p1 = overdue.filter((t: any) => t.priority === 4);
       if (p1.length === 0) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
       return {
         triggered: true,
         confidence: 1.0,
-        data: { count: p1.length, tasks: p1.slice(0, 10).map(t => t.content) },
+        data: { count: p1.length, tasks: p1.slice(0, 10).map((t: any) => t.content) },
         title: `${p1.length} priority-1 task${p1.length > 1 ? 's are' : ' is'} overdue`,
-        description: p1.slice(0, 5).map(t => `• ${t.content}`).join('\n'),
+        description: p1.slice(0, 5).map((t: any) => `• ${t.content}`).join('\n'),
       };
     },
   },
@@ -890,8 +887,9 @@ export const rules: SignalRule[] = [
     severity: 'warning',
     name: 'Low Stannp Balance',
     evaluate(current: any): RuleResult {
-      const balance = current?.account_balance ?? 0;
-      if (balance >= 50) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
+      const balance = current?.account_balance;
+      // No balance data at all (fresh/empty sync) is not the same as £0.
+      if (typeof balance !== 'number' || balance >= 50) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
       return {
         triggered: true,
         confidence: 1.0,
@@ -909,14 +907,14 @@ export const rules: SignalRule[] = [
     severity: 'alert',
     name: 'Stannp Campaign Failed',
     evaluate(current: any): RuleResult {
-      const failed = (current?.campaigns ?? []).filter(c => c.status === 'failed');
+      const failed = (current?.campaigns ?? []).filter((c: any) => c.status === 'failed');
       if (failed.length === 0) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
       return {
         triggered: true,
         confidence: 1.0,
-        data: { count: failed.length, campaigns: failed.map(c => c.name) },
+        data: { count: failed.length, campaigns: failed.map((c: any) => c.name) },
         title: `${failed.length} Stannp campaign${failed.length > 1 ? 's' : ''} failed`,
-        description: failed.map(c => `${c.name} (#${c.id})`).join(', '),
+        description: failed.map((c: any) => `${c.name} (#${c.id})`).join(', '),
       };
     },
   },
@@ -1217,8 +1215,9 @@ export const rules: SignalRule[] = [
     severity: 'info',
     name: 'No Recent GBP Posts',
     evaluate(current: any): RuleResult {
-      const days = current?.days_since_post ?? 999;
-      if (days <= 14) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
+      const days = current?.days_since_post;
+      // Missing data (fresh/empty sync) must not read as "999 days since post".
+      if (typeof days !== 'number' || days <= 14) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
       return {
         triggered: true,
         confidence: 0.9,
@@ -1400,13 +1399,13 @@ export const rules: SignalRule[] = [
     evaluate(current: any): RuleResult {
       const count = current?.blueprint_prs_open ?? 0;
       if (count === 0) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
-      const titles = (current?.blueprint_prs_data ?? []).map(p => p.title);
+      const titles = (current?.blueprint_prs_data ?? []).map((p: any) => p.title);
       return {
         triggered: true,
         confidence: 1.0,
         data: { count, titles },
         title: `${count} Blueprint-created PR${count > 1 ? 's' : ''} awaiting review`,
-        description: titles.slice(0, 5).map(t => `• ${t}`).join('\n'),
+        description: titles.slice(0, 5).map((t: any) => `• ${t}`).join('\n'),
       };
     },
   },
@@ -1687,12 +1686,12 @@ export const rules: SignalRule[] = [
     name: 'Low Quality Score Keywords',
     evaluate(current: any): RuleResult {
       const keywords = current?.keywords_data ?? [];
-      const lowQS = keywords.filter(k => (k.quality_score ?? 10) < 5 && (k.cost_micros ?? 0) > 1_000_000);
+      const lowQS = keywords.filter((k: any) => (k.quality_score ?? 10) < 5 && (k.cost_micros ?? 0) > 1_000_000);
       if (lowQS.length <= 3) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
       return {
         triggered: true,
         confidence: 0.8,
-        data: { count: lowQS.length, keywords: lowQS.slice(0, 10).map(k => k.text) },
+        data: { count: lowQS.length, keywords: lowQS.slice(0, 10).map((k: any) => k.text) },
         title: `${lowQS.length} keywords with quality score below 5`,
         description: 'Low quality scores increase costs. Improve landing page relevance and ad copy.',
       };
@@ -1709,7 +1708,7 @@ export const rules: SignalRule[] = [
     type: 'klaviyo_open_rate_drop',
     severity: 'warning',
     name: 'Klaviyo Open Rate Drop',
-    evaluate(current = {}, previous = {}) {
+    evaluate(current: any = {}, previous: any = {}): RuleResult {
       const curr = Number(current.campaign_open_rate ?? 0);
       const prev = Number(previous.campaign_open_rate ?? 0);
       if (!(prev > 0)) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
@@ -1776,7 +1775,7 @@ export const rules: SignalRule[] = [
     type: 'klaviyo_revenue_drop',
     severity: 'alert',
     name: 'Klaviyo Attributed Revenue Drop',
-    evaluate(current = {}, previous = {}) {
+    evaluate(current: any = {}, previous: any = {}): RuleResult {
       const curr = Number(current.total_attributed_revenue_30d ?? 0);
       const prev = Number(previous.total_attributed_revenue_30d ?? 0);
       if (!(prev > 0)) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
@@ -1867,7 +1866,7 @@ export const rules: SignalRule[] = [
     type: 'semrush_traffic_value_drop',
     severity: 'warning',
     name: 'SEMrush Organic Traffic Value Drop',
-    evaluate(current = {}, previous = {}) {
+    evaluate(current: any = {}, previous: any = {}): RuleResult {
       const curr = Number(current.organic_cost_estimate ?? 0);
       const prev = Number(previous.organic_cost_estimate ?? 0);
       if (!(prev > 0)) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
@@ -1891,7 +1890,7 @@ export const rules: SignalRule[] = [
     type: 'semrush_competitor_surge',
     severity: 'info',
     name: 'SEMrush Competitor Surge',
-    evaluate(current = {}, previous = {}) {
+    evaluate(current: any = {}, previous: any = {}): RuleResult {
       const currCompetitors = Array.isArray(current.competitors_data) ? current.competitors_data : [];
       const prevCompetitors = Array.isArray(previous.competitors_data) ? previous.competitors_data : [];
       if (currCompetitors.length === 0 || prevCompetitors.length === 0) {
@@ -1900,9 +1899,9 @@ export const rules: SignalRule[] = [
       const ourTraffic = Number(current.organic_traffic_estimate ?? 0);
       const ourPrevTraffic = Number(previous.organic_traffic_estimate ?? 0);
       const ourChange = ourPrevTraffic > 0 ? (ourTraffic - ourPrevTraffic) / ourPrevTraffic : 0;
-      const prevMap = new Map(prevCompetitors.map((c) => [c.domain, c]));
+      const prevMap = new Map<string, any>(prevCompetitors.map((c: any) => [c.domain, c]));
       const surging = currCompetitors
-        .map((c) => {
+        .map((c: any) => {
           const p = prevMap.get(c.domain);
           if (!p || !(p.organic_traffic > 0)) return null;
           const change = (c.organic_traffic - p.organic_traffic) / p.organic_traffic;
@@ -1930,14 +1929,14 @@ export const rules: SignalRule[] = [
     name: 'SEMrush Page-2 Keyword Opportunity',
     evaluate(current: any = {}): RuleResult {
       const ops = Array.isArray(current.opportunities_data) ? current.opportunities_data : [];
-      const high = ops.filter((k) => Number(k.search_volume) >= 500);
+      const high = ops.filter((k: any) => Number(k.search_volume) >= 500);
       const triggered = high.length > 0;
       return {
         triggered,
         confidence: triggered ? Math.min(0.85, 0.5 + high.length * 0.05) : 0,
         data: {
           total: high.length,
-          keywords: high.slice(0, 10).map((k) => ({
+          keywords: high.slice(0, 10).map((k: any) => ({
             keyword: k.keyword,
             position: k.position,
             volume: k.search_volume,
@@ -1958,7 +1957,7 @@ export const rules: SignalRule[] = [
     type: 'semrush_backlink_growth',
     severity: 'info',
     name: 'SEMrush Backlink Growth',
-    evaluate(current = {}, previous = {}) {
+    evaluate(current: any = {}, previous: any = {}): RuleResult {
       const curr = Number(current.referring_domains ?? 0);
       const prev = Number(previous.referring_domains ?? 0);
       if (!(prev > 0)) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
@@ -1982,7 +1981,7 @@ export const rules: SignalRule[] = [
     type: 'semrush_traffic_milestone',
     severity: 'info',
     name: 'SEMrush Traffic Milestone',
-    evaluate(current = {}, previous = {}) {
+    evaluate(current: any = {}, previous: any = {}): RuleResult {
       const curr = Number(current.organic_traffic_estimate ?? 0);
       const prev = Number(previous.organic_traffic_estimate ?? 0);
       const milestones = [1000, 5000, 10000, 25000, 50000, 100000];
@@ -2008,7 +2007,7 @@ export const rules: SignalRule[] = [
     type: 'fb_reach_drop',
     severity: 'warning',
     name: 'Facebook Reach Drop',
-    evaluate(current = {}, previous = {}) {
+    evaluate(current: any = {}, previous: any = {}): RuleResult {
       const curr = Number(current['fb.page_reach_30d'] ?? current.fb_page_reach_30d ?? 0);
       const prev = Number(previous['fb.page_reach_30d'] ?? previous.fb_page_reach_30d ?? 0);
       if (!(prev > 0)) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
@@ -2032,7 +2031,7 @@ export const rules: SignalRule[] = [
     type: 'ig_follower_loss',
     severity: 'warning',
     name: 'Instagram Follower Loss',
-    evaluate(current = {}, previous = {}) {
+    evaluate(current: any = {}, previous: any = {}): RuleResult {
       const curr = Number(current['ig.followers'] ?? current.ig_followers ?? 0);
       const prev = Number(previous['ig.followers'] ?? previous.ig_followers ?? 0);
       if (!(prev > 0)) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
@@ -2056,7 +2055,7 @@ export const rules: SignalRule[] = [
     type: 'ig_engagement_drop',
     severity: 'info',
     name: 'Instagram Engagement Drop',
-    evaluate(current = {}, previous = {}) {
+    evaluate(current: any = {}, previous: any = {}): RuleResult {
       const curr = Number(current['ig.avg_post_engagement_rate'] ?? current.ig_avg_post_engagement_rate ?? 0);
       const prev = Number(previous['ig.avg_post_engagement_rate'] ?? previous.ig_avg_post_engagement_rate ?? 0);
       if (!(prev > 0)) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
@@ -2081,8 +2080,14 @@ export const rules: SignalRule[] = [
     severity: 'info',
     name: 'Social Posting Gap',
     evaluate(current: any = {}): RuleResult {
-      const fbPosts = Number(current['fb.posts_published_30d'] ?? current.fb_posts_published_30d ?? 0);
-      const igPosts = Number(current['ig.posts_published_30d'] ?? current.ig_posts_published_30d ?? 0);
+      const fbRaw = current?.['fb.posts_published_30d'] ?? current?.fb_posts_published_30d;
+      const igRaw = current?.['ig.posts_published_30d'] ?? current?.ig_posts_published_30d;
+      // No posting data at all (fresh/empty sync) is not a posting gap.
+      if (fbRaw === undefined && igRaw === undefined) {
+        return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
+      }
+      const fbPosts = Number(fbRaw ?? 0);
+      const igPosts = Number(igRaw ?? 0);
       const total = fbPosts + igPosts;
       const triggered = total < 4;
       return {
@@ -2130,15 +2135,15 @@ export const rules: SignalRule[] = [
         ? current['fb.recent_posts_data']
         : Array.isArray(current.fb_recent_posts_data) ? current.fb_recent_posts_data : [];
       if (posts.length < 3) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
-      const avg = posts.reduce((s, p) => s + (p.reach || 0), 0) / posts.length;
+      const avg = posts.reduce((s: any, p: any) => s + (p.reach || 0), 0) / posts.length;
       if (avg <= 0) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
-      const winners = posts.filter((p) => (p.reach || 0) >= avg * 3);
+      const winners = posts.filter((p: any) => (p.reach || 0) >= avg * 3);
       const triggered = winners.length > 0;
       return {
         triggered,
         confidence: triggered ? 0.75 : 0,
         data: {
-          winners: winners.slice(0, 3).map((p) => ({
+          winners: winners.slice(0, 3).map((p: any) => ({
             message: (p.message || '').slice(0, 150),
             reach: p.reach,
             url: p.permalink_url,
@@ -2162,7 +2167,12 @@ export const rules: SignalRule[] = [
     severity: 'info',
     name: 'Buffer Queue Empty',
     evaluate(current: any = {}): RuleResult {
-      const pending = Number(current['buffer.posts_scheduled_pending'] ?? current.buffer_posts_scheduled_pending ?? 0);
+      const pendingRaw = current?.['buffer.posts_scheduled_pending'] ?? current?.buffer_posts_scheduled_pending;
+      // No queue data at all (fresh/empty sync) is not an empty queue.
+      if (pendingRaw === undefined) {
+        return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
+      }
+      const pending = Number(pendingRaw);
       const triggered = pending === 0;
       return {
         triggered,
@@ -2183,7 +2193,12 @@ export const rules: SignalRule[] = [
     severity: 'warning',
     name: 'Buffer Posting Gap',
     evaluate(current: any = {}): RuleResult {
-      const freq = Number(current['buffer.posting_frequency_7d'] ?? current.buffer_posting_frequency_7d ?? 0);
+      const freqRaw = current?.['buffer.posting_frequency_7d'] ?? current?.buffer_posting_frequency_7d;
+      // No posting data at all (fresh/empty sync) is not a posting gap.
+      if (freqRaw === undefined) {
+        return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
+      }
+      const freq = Number(freqRaw);
       const triggered = freq < 1;
       return {
         triggered,
@@ -2203,7 +2218,7 @@ export const rules: SignalRule[] = [
     type: 'buffer_low_engagement',
     severity: 'info',
     name: 'Buffer Engagement Drop',
-    evaluate(current = {}, previous = {}) {
+    evaluate(current: any = {}, previous: any = {}): RuleResult {
       const curr = Number(current['buffer.avg_post_engagement_30d'] ?? current.buffer_avg_post_engagement_30d ?? 0);
       const prev = Number(previous['buffer.avg_post_engagement_30d'] ?? previous.buffer_avg_post_engagement_30d ?? 0);
       if (!(prev > 0)) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
@@ -2341,7 +2356,7 @@ export const rules: SignalRule[] = [
     type: 'wix_seo_score_drop',
     severity: 'warning',
     name: 'Wix SEO Score Drop',
-    evaluate(current = {}, previous = {}) {
+    evaluate(current: any = {}, previous: any = {}): RuleResult {
       const curr = Number(current['wix.seo_score'] ?? 0);
       const prev = Number(previous['wix.seo_score'] ?? 0);
       if (!(prev > 0)) return { triggered: false, confidence: 0, data: {}, title: '', description: '' };
@@ -2473,7 +2488,7 @@ export const rules: SignalRule[] = [
 
 function _num(v: unknown): number {
   if (v === null || v === undefined || v === '') return 0;
-  const n = typeof v === 'number' ? v : parseFloat(v);
+  const n = typeof v === 'number' ? v : parseFloat(v as string);
   return Number.isFinite(n) ? n : 0;
 }
 
@@ -2506,7 +2521,7 @@ export function flattenMeta(payload: unknown): { roas: number; cpm: number; cpc:
   }
 
   const raw = payload as Record<string, unknown>;
-  const current = (raw.account as Record<string, unknown> | undefined)?.data?.[0] as Record<string, unknown> ?? {};
+  const current = ((raw.account as Record<string, unknown> | undefined)?.data as any[])?.[0] as Record<string, unknown> ?? {};
   const spend = _num(current.spend);
   const revenue = _getAction(current.action_values, 'purchase');
   return {
@@ -2522,7 +2537,7 @@ export function flattenMeta(payload: unknown): { roas: number; cpm: number; cpc:
 export function flattenMetaPrev(payload: unknown): { roas: number; cpm: number; cpc: number; ctr: number; spend_30d: number; frequency: number } | null {
   if (!payload || typeof payload !== 'object') return null;
   const rawP = payload as Record<string, unknown>;
-  const prev = (rawP.previous as Record<string, unknown> | undefined)?.data?.[0] as Record<string, unknown> | undefined;
+  const prev = ((rawP.previous as Record<string, unknown> | undefined)?.data as any[])?.[0] as Record<string, unknown> | undefined;
   if (!prev) return null;
   const spend = _num(prev.spend);
   const revenue = _getAction(prev.action_values, 'purchase');

--- a/server/signals/signal-engine.ts
+++ b/server/signals/signal-engine.ts
@@ -79,7 +79,9 @@ export async function runSignalEngine(
   for (const rule of applicableRules) {
     let result: RuleResult;
     try {
-      result = rule.evaluate(currentData, previousData);
+      // Normalise null → undefined so rules' `= {}` parameter defaults kick
+      // in. Many rules access fields directly and would throw on null.
+      result = rule.evaluate(currentData ?? undefined, previousData ?? undefined);
     } catch (err) {
       console.error(`[signal-engine] Rule '${rule.id}' threw during evaluate():`, (err as Error).message);
       continue;


### PR DESCRIPTION
# Full-codebase audit pass

Result of a structured audit (architecture → run/verify → TypeScript → connectors → metrics → security → tests). Typecheck, the full test suite (71 → **85 passing**), and the client build are all green.

## Bug fixes

- **Google Ads: wrong comparison period (business-damaging).** The "previous period" GAQL query was hardcoded to `BETWEEN '2025-03-01' AND '2025-03-31'`, so every period-over-period comparison was against March 2025 forever. Now a rolling 31–60-days-ago window. Swallowed query failures are now logged.
- **Five signal rules raised false alarms on empty data.** `low_campaign_balance` ("Stannp balance low: £0.00"), `gbp_no_recent_posts` ("No GBP posts in 999 days"), `social_posting_gap`, `buffer_queue_empty`, `buffer_posting_gap` all triggered when a connector simply had no data yet. Missing data is now distinguished from a real zero.
- **Goals page timezone bug.** Deadline countdown parsed SQLite naive UTC timestamps as local time (off by the user's UTC offset); now uses the shared `parseTimestamp` helper.
- **Startup signal-handler crash.** SIGTERM/SIGINT arriving during boot hit a temporal-dead-zone `ReferenceError` on the `server` handle.

## Hardening

- **Session security:** the server now refuses to start in production without `SESSION_SECRET` instead of silently using a hardcoded dev fallback.
- **Meta Ads pagination:** campaigns, ad sets, and campaign-level insights follow Graph API `paging.next` cursors (capped at 10 pages, with a warning if capped) instead of silently truncating at the first page — accounts with >50 campaigns previously lost data.
- **GBP partial-failure visibility:** the six parallel section fetches (reviews, insights, posts, photos, Q&A, location) previously swallowed errors via bare `.catch(() => fallback)`. Failures are now logged and reported in a `partial_failures` field so "no reviews" and "reviews fetch failed" are distinguishable downstream.
- **Retry helper:** `withRetry` now also retries 502/504 gateway errors and honours `Retry-After` headers (delta-seconds or HTTP-date, capped at 60s), which `checkedFetch` now surfaces.
- **Stripe:** removed the `apiVersion: '2024-06-20' as any` cast; the SDK's pinned, typed version is used.
- **ROI value estimator:** conversion-rate baselines normalised with a plausibility check (>20% treated as percent, >50% after conversion rejected with a warning) instead of the fragile `>1 ⇒ percent` heuristic.

## Type safety

- `server/signals/rules.ts` (~2,500 lines, the core metric-trustworthiness file) no longer uses `@ts-nocheck` — the whole file now typechecks. Annotation-only changes; no thresholds, formulas, or strings touched.

## Tests added

- `server/lib/rate-limiter.test.ts` — retry on 429/502/503/504, no retry on 4xx/500/plain errors, retry exhaustion, Retry-After hint precedence.
- `server/signals/rules.test.ts` — a contract test asserting **no rule may false-alarm on empty input** (this is what caught the five buggy rules), divide-by-zero guards, trigger thresholds, and result-shape invariants across all ~80 rules.

## Verified

- `tsc --noEmit` clean on both server and client
- `bun test`: 85 pass / 0 fail
- `vite build`: clean

https://claude.ai/code/session_01HFVWLNSxz3ipRyjJzvPxTJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFVWLNSxz3ipRyjJzvPxTJ)_